### PR TITLE
fix: ユーザー名にハイフンを許可する

### DIFF
--- a/src/routes/signup/+page.server.ts
+++ b/src/routes/signup/+page.server.ts
@@ -25,9 +25,9 @@ export const actions: Actions = {
 			return fail(400, { error: 'Username must be between 3 and 15 characters', username });
 		}
 
-		if (!/^[a-zA-Z0-9_]+$/.test(username)) {
+		if (!/^[a-zA-Z0-9_-]+$/.test(username)) {
 			return fail(400, {
-				error: 'Username can only contain letters, numbers, and underscores',
+				error: 'Username can only contain letters, numbers, underscores, and hyphens',
 				username
 			});
 		}


### PR DESCRIPTION
## 関連 Issue
closes #1

## 変更内容
- `src/routes/signup/+page.server.ts` のユーザー名バリデーション正規表現にハイフン(`-`)を追加
- エラーメッセージを更新

本家HNではハイフン入りユーザー名（例: `kako-jun`）が使えるため、同様に許可する。