### PR TITLE
feat: プロフィール・投稿・コメントの編集機能を追加

### DIFF
--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -189,6 +189,19 @@ export async function getVotedStoryIds(
 	return new Set(result.results.map((r) => r.item_id));
 }
 
+export async function getCommentById(db: D1Database, id: number): Promise<CommentRow | null> {
+	const result = await db
+		.prepare(
+			`SELECT c.*, u.username
+			FROM comments c
+			JOIN users u ON c.user_id = u.id
+			WHERE c.id = ?`
+		)
+		.bind(id)
+		.first<CommentRow>();
+	return result;
+}
+
 export async function getVotedCommentIds(
 	db: D1Database,
 	userId: number,

--- a/src/routes/item/[id]/+page.server.ts
+++ b/src/routes/item/[id]/+page.server.ts
@@ -1,5 +1,5 @@
 import type { PageServerLoad, Actions } from './$types';
-import { getDB, getStoryById, getCommentsByStoryId, getVotedCommentIds, hasVoted } from '$lib/server/db';
+import { getDB, getStoryById, getCommentsByStoryId, getCommentById, getVotedCommentIds, hasVoted } from '$lib/server/db';
 import { error, fail, redirect } from '@sveltejs/kit';
 
 export const load: PageServerLoad = async ({ params, platform, locals }) => {
@@ -65,6 +65,87 @@ export const actions: Actions = {
 		await db
 			.prepare('UPDATE stories SET comment_count = comment_count + 1 WHERE id = ?')
 			.bind(storyId)
+			.run();
+
+		return { success: true };
+	},
+
+	editStory: async ({ request, platform, locals, params }) => {
+		if (!locals.user) {
+			throw redirect(302, '/login');
+		}
+
+		const db = getDB(platform);
+		const storyId = parseInt(params.id, 10);
+		const story = await getStoryById(db, storyId);
+
+		if (!story) {
+			throw error(404, 'Story not found');
+		}
+
+		if (story.user_id !== locals.user.id) {
+			throw error(403, 'Cannot edit another user\'s story');
+		}
+
+		const elapsed = Date.now() - new Date(story.created_at).getTime();
+		if (elapsed >= 2 * 60 * 60 * 1000) {
+			return fail(400, { error: 'Editing window has expired (2 hours)' });
+		}
+
+		const formData = await request.formData();
+		const title = (formData.get('title') as string)?.trim();
+		const text = (formData.get('text') as string) ?? '';
+
+		if (!title) {
+			return fail(400, { error: 'Title is required' });
+		}
+
+		let type = 'story';
+		if (title.startsWith('Ask HN:')) {
+			type = 'ask';
+		} else if (title.startsWith('Show HN:')) {
+			type = 'show';
+		}
+
+		await db
+			.prepare('UPDATE stories SET title = ?, text = ?, type = ? WHERE id = ?')
+			.bind(title, text || null, type, storyId)
+			.run();
+
+		return { success: true };
+	},
+
+	editComment: async ({ request, platform, locals }) => {
+		if (!locals.user) {
+			throw redirect(302, '/login');
+		}
+
+		const db = getDB(platform);
+		const formData = await request.formData();
+		const commentId = parseInt(formData.get('comment_id') as string, 10);
+		const text = (formData.get('text') as string)?.trim();
+
+		if (!text) {
+			return fail(400, { error: 'Comment text is required' });
+		}
+
+		const comment = await getCommentById(db, commentId);
+		if (!comment) {
+			throw error(404, 'Comment not found');
+		}
+
+		if (comment.user_id !== locals.user.id) {
+			throw error(403, 'Cannot edit another user\'s comment');
+		}
+
+		const elapsed = Date.now() - new Date(comment.created_at).getTime();
+		if (elapsed >= 2 * 60 * 60 * 1000) {
+			return fail(400, { error: 'Editing window has expired (2 hours)' });
+		}
+
+		await db
+			.prepare('UPDATE comments SET text = ? WHERE id = ?')
+			.bind(text, commentId)
 			.run();
 
 		return { success: true };

--- a/src/routes/item/[id]/+page.svelte
+++ b/src/routes/item/[id]/+page.svelte
@@ -9,6 +9,14 @@
 	let localVotedCommentIds = $state<Set<number> | null>(null);
 	let localCommentPoints = $state<Record<number, number>>({});
 	let replyTo = $state<number | null>(null);
+	let editingStory = $state(false);
+	let editingCommentId = $state<number | null>(null);
+
+	function canEdit(createdAt: string, userId: number): boolean {
+		if (!data.user || data.user.id !== userId) return false;
+		const elapsed = Date.now() - new Date(createdAt).getTime();
+		return elapsed < 2 * 60 * 60 * 1000;
+	}
 
 	let storyVoted = $derived(localStoryVoted ?? data.storyVoted);
 	let storyPoints = $derived(localStoryPoints ?? data.story.points);
@@ -144,9 +152,48 @@
 		{storyPoints} point{storyPoints !== 1 ? 's' : ''} by
 		<a href="/user/{data.story.username}">{data.story.username}</a>
 		{timeAgo(data.story.created_at)}
+		{#if canEdit(data.story.created_at, data.story.user_id)}
+			| <a
+				href="#edit"
+				onclick={(e) => {
+					e.preventDefault();
+					editingStory = true;
+				}}>edit</a>
+		{/if}
 	</div>
 
-	{#if data.story.text}
+	{#if editingStory}
+		<div class="comment-form" style="padding-left: 18px;">
+			<form method="POST" action="?/editStory" use:enhance={() => {
+				return async ({ update }) => {
+					editingStory = false;
+					await update();
+					await invalidateAll();
+				};
+			}}>
+				<table style="border-spacing: 0;">
+					<tbody>
+						<tr>
+							<td style="color: #828282; text-align: right; padding: 2px 5px; vertical-align: top;">title:</td>
+							<td style="padding: 2px 5px;"><input type="text" name="title" value={data.story.title} style="font-family: monospace; font-size: 9pt; width: 300px;" /></td>
+						</tr>
+						<tr>
+							<td style="color: #828282; text-align: right; padding: 2px 5px; vertical-align: top;">text:</td>
+							<td style="padding: 2px 5px;"><textarea name="text" rows="6" cols="60">{data.story.text ?? ''}</textarea></td>
+						</tr>
+					</tbody>
+				</table>
+				<button type="submit">update</button>
+				<a
+					href="#cancel"
+					onclick={(e) => {
+						e.preventDefault();
+						editingStory = false;
+					}}
+					style="margin-left: 8px; font-size: 7pt; color: #828282;">cancel</a>
+			</form>
+		</div>
+	{:else if data.story.text}
 		<div class="item-text" style="padding-left: 18px;">
 			{#each data.story.text.split('\n') as paragraph}
 				{#if paragraph.trim()}
@@ -188,13 +235,37 @@
 					<a href="/user/{comment.username}">{comment.username}</a>
 					{timeAgo(comment.created_at)}
 				</div>
-				<div class="comment-text" style="padding-left: 14px;">
-					{#each comment.text.split('\n') as paragraph}
-						{#if paragraph.trim()}
-							<p>{paragraph}</p>
-						{/if}
-					{/each}
-				</div>
+				{#if editingCommentId === comment.id}
+					<div class="comment-form" style="padding-left: 14px;">
+						<form method="POST" action="?/editComment" use:enhance={() => {
+							return async ({ update }) => {
+								editingCommentId = null;
+								await update();
+								await invalidateAll();
+							};
+						}}>
+							<input type="hidden" name="comment_id" value={comment.id} />
+							<textarea name="text" rows="4" cols="60">{comment.text}</textarea>
+							<br />
+							<button type="submit">update</button>
+							<a
+								href="#cancel"
+								onclick={(e) => {
+									e.preventDefault();
+									editingCommentId = null;
+								}}
+								style="margin-left: 8px; font-size: 7pt; color: #828282;">cancel</a>
+						</form>
+					</div>
+				{:else}
+					<div class="comment-text" style="padding-left: 14px;">
+						{#each comment.text.split('\n') as paragraph}
+							{#if paragraph.trim()}
+								<p>{paragraph}</p>
+							{/if}
+						{/each}
+					</div>
+				{/if}
 				{#if data.user}
 					<div class="comment-reply" style="padding-left: 14px;">
 						<a
@@ -204,6 +275,14 @@
 								toggleReply(comment.id);
 							}}>reply</a
 						>
+						{#if canEdit(comment.created_at, comment.user_id)}
+							| <a
+								href="#edit"
+								onclick={(e) => {
+									e.preventDefault();
+									editingCommentId = comment.id;
+								}}>edit</a>
+						{/if}
 					</div>
 					{#if replyTo === comment.id}
 						<div class="comment-form" style="padding-left: 14px;">

--- a/src/routes/user/[id]/+page.server.ts
+++ b/src/routes/user/[id]/+page.server.ts
@@ -1,6 +1,6 @@
-import type { PageServerLoad } from './$types';
+import type { PageServerLoad, Actions } from './$types';
 import { getDB, getUserByUsername, getStoriesByUserId, getVotedStoryIds } from '$lib/server/db';
-import { error } from '@sveltejs/kit';
+import { error, fail } from '@sveltejs/kit';
 
 export const load: PageServerLoad = async ({ params, platform, locals }) => {
 	const db = getDB(platform);
@@ -22,6 +22,8 @@ export const load: PageServerLoad = async ({ params, platform, locals }) => {
 		);
 	}
 
+	const isOwnProfile = locals.user?.username === user.username;
+
 	return {
 		profile: {
 			id: user.id,
@@ -31,6 +33,30 @@ export const load: PageServerLoad = async ({ params, platform, locals }) => {
 			created_at: user.created_at
 		},
 		submissions,
-		votedIds: Array.from(votedIds)
+		votedIds: Array.from(votedIds),
+		isOwnProfile
 	};
+};
+
+export const actions: Actions = {
+	update: async ({ request, platform, locals, params }) => {
+		if (!locals.user) {
+			throw error(401, 'Not logged in');
+		}
+
+		if (locals.user.username !== params.id) {
+			throw error(403, 'Cannot edit another user\'s profile');
+		}
+
+		const db = getDB(platform);
+		const formData = await request.formData();
+		const about = (formData.get('about') as string) ?? '';
+
+		await db
+			.prepare('UPDATE users SET about = ? WHERE username = ?')
+			.bind(about, params.id)
+			.run();
+
+		return { success: true };
+	}
 };

--- a/src/routes/user/[id]/+page.svelte
+++ b/src/routes/user/[id]/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+	import { enhance } from '$app/forms';
 	import { timeAgo, extractDomain } from '$lib/ranking';
 
-	let { data } = $props();
+	let { data, form } = $props();
 
 	function formatDate(dateString: string): string {
 		const date = new Date(dateString);
@@ -28,7 +29,18 @@
 				<td>karma:</td>
 				<td>{data.profile.karma}</td>
 			</tr>
-			{#if data.profile.about}
+			{#if data.isOwnProfile}
+				<tr>
+					<td>about:</td>
+					<td>
+						<form method="POST" action="?/update" use:enhance>
+							<textarea name="about" rows="5" cols="60">{data.profile.about ?? ''}</textarea>
+							<br />
+							<button type="submit">update</button>
+						</form>
+					</td>
+				</tr>
+			{:else if data.profile.about}
 				<tr>
 					<td>about:</td>
 					<td>{data.profile.about}</td>


### PR DESCRIPTION
## 関連 Issue
closes #5
closes #6

## 変更内容

### プロフィール編集 (#5)
- 自分のプロフィールページで about フィールドを編集・更新可能に
- 他人のプロフィールは従来通り読み取り専用

### 投稿・コメント編集 (#6)
- 投稿から2時間以内の自分のストーリー/コメントに「edit」リンクを表示
- ストーリー: title と text をインライン編集可能
- コメント: text をインライン編集可能
- 編集時にストーリーの type（ask/show/story）を再判定
- db.ts に `getCommentById()` を追加

### 変更ファイル
- `src/lib/server/db.ts` — getCommentById 追加
- `src/routes/user/[id]/` — isOwnProfile + update アクション
- `src/routes/item/[id]/` — editStory / editComment アクション + 編集UI