### PR TITLE
feat: プロフィールに submissions/comments リンクを追加

### DIFF
--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -189,6 +189,28 @@ export async function getVotedStoryIds(
 	return new Set(result.results.map((r) => r.item_id));
 }
 
+export async function getCommentsByUserId(
+	db: D1Database,
+	userId: number,
+	page: number = 1,
+	limit: number = 30
+): Promise<(CommentRow & { story_title: string })[]> {
+	const offset = (page - 1) * limit;
+	const result = await db
+		.prepare(
+			`SELECT c.*, u.username, s.title as story_title
+			FROM comments c
+			JOIN users u ON c.user_id = u.id
+			JOIN stories s ON c.story_id = s.id
+			WHERE c.user_id = ?
+			ORDER BY c.created_at DESC
+			LIMIT ? OFFSET ?`
+		)
+		.bind(userId, limit, offset)
+		.all();
+	return result.results as any;
+}
+
 export async function getCommentById(db: D1Database, id: number): Promise<CommentRow | null> {
 	const result = await db
 		.prepare(

--- a/src/routes/user/[id]/+page.server.ts
+++ b/src/routes/user/[id]/+page.server.ts
@@ -1,5 +1,5 @@
 import type { PageServerLoad, Actions } from './$types';
-import { getDB, getUserByUsername, getStoriesByUserId, getVotedStoryIds } from '$lib/server/db';
+import { getDB, getUserByUsername } from '$lib/server/db';
 import { error, fail } from '@sveltejs/kit';
 
 export const load: PageServerLoad = async ({ params, platform, locals }) => {
@@ -9,17 +9,6 @@ export const load: PageServerLoad = async ({ params, platform, locals }) => {
 	const user = await getUserByUsername(db, username);
 	if (!user) {
 		throw error(404, 'User not found');
-	}
-
-	const submissions = await getStoriesByUserId(db, user.id, 1, 30);
-
-	let votedIds: Set<number> = new Set();
-	if (locals.user) {
-		votedIds = await getVotedStoryIds(
-			db,
-			locals.user.id,
-			submissions.map((s) => s.id)
-		);
 	}
 
 	const isOwnProfile = locals.user?.username === user.username;
@@ -32,8 +21,6 @@ export const load: PageServerLoad = async ({ params, platform, locals }) => {
 			about: user.about,
 			created_at: user.created_at
 		},
-		submissions,
-		votedIds: Array.from(votedIds),
 		isOwnProfile
 	};
 };

--- a/src/routes/user/[id]/+page.svelte
+++ b/src/routes/user/[id]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
-	import { timeAgo, extractDomain } from '$lib/ranking';
 
 	let { data, form } = $props();
 
@@ -49,35 +48,8 @@
 		</tbody>
 	</table>
 
-	{#if data.submissions.length > 0}
-		<h3 style="font-size: 10pt; margin-top: 20px; margin-bottom: 5px; color: #828282;">submissions</h3>
-		<div class="story-list">
-			{#each data.submissions as story, i}
-				<div class="story-item">
-					<span class="story-rank">{i + 1}.</span>
-					<span class="story-vote">
-						<span class="upvote">&#9650;</span>
-					</span>
-					<div class="story-content">
-						<div class="story-title-line">
-							{#if story.url}
-								<a href={story.url} class="story-title">{story.title}</a>
-								<span class="story-domain">({extractDomain(story.url)})</span>
-							{:else}
-								<a href="/item/{story.id}" class="story-title">{story.title}</a>
-							{/if}
-						</div>
-						<div class="story-meta">
-							{story.points} point{story.points !== 1 ? 's' : ''} by
-							<a href="/user/{story.username}">{story.username}</a>
-							<a href="/item/{story.id}">{timeAgo(story.created_at)}</a> |
-							<a href="/item/{story.id}"
-								>{story.comment_count} comment{story.comment_count !== 1 ? 's' : ''}</a
-							>
-						</div>
-					</div>
-				</div>
-			{/each}
-		</div>
-	{/if}
+	<div style="margin-top: 10px; font-size: 10pt;">
+		<a href="/user/{data.profile.username}/submissions">submissions</a><br />
+		<a href="/user/{data.profile.username}/comments">comments</a>
+	</div>
 </div>

--- a/src/routes/user/[id]/comments/+page.server.ts
+++ b/src/routes/user/[id]/comments/+page.server.ts
@@ -1,0 +1,22 @@
+import type { PageServerLoad } from './$types';
+import { getDB, getUserByUsername, getCommentsByUserId } from '$lib/server/db';
+import { error } from '@sveltejs/kit';
+
+export const load: PageServerLoad = async ({ params, url, platform }) => {
+	const db = getDB(platform);
+	const username = params.id;
+	const page = parseInt(url.searchParams.get('p') || '1', 10);
+
+	const user = await getUserByUsername(db, username);
+	if (!user) {
+		throw error(404, 'User not found');
+	}
+
+	const comments = await getCommentsByUserId(db, user.id, page, 30);
+
+	return {
+		username: user.username,
+		comments,
+		page
+	};
+};

--- a/src/routes/user/[id]/comments/+page.svelte
+++ b/src/routes/user/[id]/comments/+page.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { timeAgo } from '$lib/ranking';
+
+	let { data } = $props();
+</script>
+
+<svelte:head>
+	<title>{data.username}'s comments | ハッカーのろし</title>
+</svelte:head>
+
+<div style="padding-left: 40px;">
+	{#each data.comments as comment}
+		<div style="padding: 10px 0;">
+			<div class="comment-head">
+				<a href="/user/{comment.username}">{comment.username}</a>
+				<a href="/item/{comment.story_id}">{timeAgo(comment.created_at)}</a>
+				| on: <a href="/item/{comment.story_id}">{comment.story_title}</a>
+			</div>
+			<div class="comment-text" style="padding-left: 14px;">
+				{#each comment.text.split('\n') as paragraph}
+					{#if paragraph.trim()}
+						<p>{paragraph}</p>
+					{/if}
+				{/each}
+			</div>
+		</div>
+	{/each}
+</div>
+
+{#if data.comments.length === 30}
+	<div class="more-link">
+		<a href="/user/{data.username}/comments?p={data.page + 1}">More</a>
+	</div>
+{/if}

--- a/src/routes/user/[id]/submissions/+page.server.ts
+++ b/src/routes/user/[id]/submissions/+page.server.ts
@@ -1,0 +1,32 @@
+import type { PageServerLoad } from './$types';
+import { getDB, getUserByUsername, getStoriesByUserId, getVotedStoryIds } from '$lib/server/db';
+import { error } from '@sveltejs/kit';
+
+export const load: PageServerLoad = async ({ params, url, platform, locals }) => {
+	const db = getDB(platform);
+	const username = params.id;
+	const page = parseInt(url.searchParams.get('p') || '1', 10);
+
+	const user = await getUserByUsername(db, username);
+	if (!user) {
+		throw error(404, 'User not found');
+	}
+
+	const submissions = await getStoriesByUserId(db, user.id, page, 30);
+
+	let votedIds: Set<number> = new Set();
+	if (locals.user) {
+		votedIds = await getVotedStoryIds(
+			db,
+			locals.user.id,
+			submissions.map((s) => s.id)
+		);
+	}
+
+	return {
+		username: user.username,
+		submissions,
+		votedIds: Array.from(votedIds),
+		page
+	};
+};

--- a/src/routes/user/[id]/submissions/+page.svelte
+++ b/src/routes/user/[id]/submissions/+page.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import { timeAgo, extractDomain } from '$lib/ranking';
+
+	let { data } = $props();
+	let votedIds = $derived(new Set(data.votedIds));
+	let localVotedIds = $state<Set<number> | null>(null);
+	let localPoints = $state<Record<number, number>>({});
+
+	function getVotedIds(): Set<number> {
+		return localVotedIds ?? votedIds;
+	}
+
+	function getPoints(story: { id: number; points: number }): number {
+		return localPoints[story.id] ?? story.points;
+	}
+
+	async function vote(storyId: number) {
+		if (!data.user) {
+			window.location.href = '/login';
+			return;
+		}
+		const res = await fetch('/api/vote', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
+		});
+		if (res.ok) {
+			const result: { voted: boolean; points: number } = await res.json();
+			localPoints = { ...localPoints, [storyId]: result.points };
+			const next = new Set(getVotedIds());
+			if (result.voted) {
+				next.add(storyId);
+			} else {
+				next.delete(storyId);
+			}
+			localVotedIds = next;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>{data.username}'s submissions | ハッカーのろし</title>
+</svelte:head>
+
+<div class="story-list" style="padding-left: 40px;">
+	{#each data.submissions as story, i}
+		<div class="story-item">
+			<span class="story-rank">{(data.page - 1) * 30 + i + 1}.</span>
+			<span class="story-vote">
+				<button
+					class="upvote"
+					class:voted={getVotedIds().has(story.id)}
+					onclick={() => vote(story.id)}
+					aria-label="upvote"
+				>
+					&#9650;
+				</button>
+			</span>
+			<div class="story-content">
+				<div class="story-title-line">
+					{#if story.url}
+						<a href={story.url} class="story-title">{story.title}</a>
+						<span class="story-domain">({extractDomain(story.url)})</span>
+					{:else}
+						<a href="/item/{story.id}" class="story-title">{story.title}</a>
+					{/if}
+				</div>
+				<div class="story-meta">
+					{getPoints(story)} point{getPoints(story) !== 1 ? 's' : ''} by
+					<a href="/user/{story.username}">{story.username}</a>
+					<a href="/item/{story.id}">{timeAgo(story.created_at)}</a> |
+					<a href="/item/{story.id}"
+						>{story.comment_count} comment{story.comment_count !== 1 ? 's' : ''}</a
+					>
+				</div>
+			</div>
+		</div>
+	{/each}
+</div>
+
+{#if data.submissions.length === 30}
+	<div class="more-link">
+		<a href="/user/{data.username}/submissions?p={data.page + 1}">More</a>
+	</div>
+{/if}


### PR DESCRIPTION
## 関連 Issue
closes #14 (favorites は別途)

## 変更内容

### 新規ルート
- `/user/[id]/submissions` — ユーザーの投稿一覧（投票機能・ページネーション付き）
- `/user/[id]/comments` — ユーザーのコメント一覧（ストーリーリンク付き・ページネーション）

### 変更
- プロフィールページからインライン submissions 表示を削除
- 代わりに submissions / comments のリンクを本家HN同様に配置
- `db.ts` に `getCommentsByUserId()` を追加

### 残作業
- favorites 機能は DB テーブル追加が必要なため別 Issue で対応