### PR TITLE
feat: コメントパーマリンクルートを追加

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,7 @@ hacker-noroshi/
 │   │   ├── newest/           # 新着順
 │   │   ├── ask/              # Ask HN
 │   │   ├── show/             # Show HN
-│   │   ├── item/[id]/        # 投稿詳細 + コメント + 編集
+│   │   ├── item/[id]/        # 投稿詳細 or コメントパーマリンク + コメント + 編集
 │   │   ├── user/[id]/        # プロフィール + 編集
 │   │   │   ├── submissions/  # ユーザーの投稿一覧
 │   │   │   └── comments/     # ユーザーのコメント一覧
@@ -117,7 +117,7 @@ hacker-noroshi/
 | `/newest` | 新着順 |
 | `/ask` | Ask HN（type='ask' のみ） |
 | `/show` | Show HN（type='show' のみ） |
-| `/item/[id]` | 投稿詳細 + コメントスレッド + 編集 |
+| `/item/[id]` | 投稿詳細 or コメントパーマリンク + コメントスレッド + 編集 |
 | `/user/[id]` | ユーザープロフィール + 編集 |
 | `/user/[id]/submissions` | ユーザーの投稿一覧 |
 | `/user/[id]/comments` | ユーザーのコメント一覧 |
@@ -138,7 +138,8 @@ hacker-noroshi/
 | `getStories()` | ストーリー一覧（ランキング or 新着、type フィルタ、ページネーション） |
 | `getStoryById()` | ストーリー1件取得 |
 | `getCommentsByStoryId()` | コメント一覧（ストーリーID指定） |
-| `getCommentById()` | コメント1件取得（編集時の権限チェック用） |
+| `getCommentById()` | コメント1件取得（編集時の権限チェック・パーマリンク用） |
+| `getChildComments()` | 特定コメントの子孫コメントを取得（パーマリンク用） |
 | `getUserByUsername()` | ユーザー取得（ユーザー名） |
 | `getUserById()` | ユーザー取得（ID） |
 | `getStoriesByUserId()` | ユーザーの投稿一覧 |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -23,6 +23,9 @@ URL: https://hn.llll-ll.com
 - ネストスレッド（40px/段のインデント）
 - トップレベルコメントまたは既存コメントへの返信
 - プレーンテキストのみ（Markdown 不可）
+- パーマリンク: `/item/{comment_id}` でコメント単体 + 子スレッドを表示
+- parent リンク（親コメント or 親ストーリーへ）、on: リンク（親ストーリーへ）
+- タイムスタンプがパーマリンクリンクを兼ねる
 
 ### 投票
 
@@ -78,6 +81,7 @@ score = (points - 1) / (hours_since_post + 2) ^ 1.8
 - [x] 投稿・コメント編集（2時間以内）
 - [x] ガイドライン・FAQ・Show HN ルールページ
 - [x] ユーザーの submissions / comments 一覧ページ
+- [x] コメントパーマリンク（/item/{comment_id}）
 
 ## v2 以降
 

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -229,8 +229,8 @@ export async function getChildComments(
 	commentId: number,
 	storyId: number
 ): Promise<CommentRow[]> {
-	// D1 lacks recursive CTE support, so fetch all comments for the story
-	// and filter to descendants of the target comment in JS
+	// TODO: D1が再帰CTEに対応したらWITH RECURSIVEで直接子孫を取得する
+	// 現状はストーリー全コメントを取得してJSでBFSフィルタ
 	const all = await getCommentsByStoryId(db, storyId);
 	const childIds = new Set<number>();
 	const queue = [commentId];

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -224,6 +224,28 @@ export async function getCommentById(db: D1Database, id: number): Promise<Commen
 	return result;
 }
 
+export async function getChildComments(
+	db: D1Database,
+	commentId: number,
+	storyId: number
+): Promise<CommentRow[]> {
+	// D1 lacks recursive CTE support, so fetch all comments for the story
+	// and filter to descendants of the target comment in JS
+	const all = await getCommentsByStoryId(db, storyId);
+	const childIds = new Set<number>();
+	const queue = [commentId];
+	while (queue.length > 0) {
+		const parentId = queue.shift()!;
+		for (const c of all) {
+			if (c.parent_id === parentId && !childIds.has(c.id)) {
+				childIds.add(c.id);
+				queue.push(c.id);
+			}
+		}
+	}
+	return all.filter((c) => childIds.has(c.id));
+}
+
 export async function getVotedCommentIds(
 	db: D1Database,
 	userId: number,

--- a/src/routes/item/[id]/+page.server.ts
+++ b/src/routes/item/[id]/+page.server.ts
@@ -68,6 +68,14 @@ export const load: PageServerLoad = async ({ params, platform, locals }) => {
 	};
 };
 
+async function resolveStoryId(db: D1Database, itemId: number): Promise<number> {
+	const story = await getStoryById(db, itemId);
+	if (story) return story.id;
+	const comment = await getCommentById(db, itemId);
+	if (comment) return comment.story_id;
+	throw error(404, 'Not found');
+}
+
 export const actions: Actions = {
 	comment: async ({ request, platform, locals, params }) => {
 		if (!locals.user) {
@@ -84,19 +92,7 @@ export const actions: Actions = {
 			return fail(400, { error: 'Comment text is required' });
 		}
 
-		// Determine story_id: if this page is a comment permalink, use its story_id
-		let storyId: number;
-		const story = await getStoryById(db, itemId);
-		if (story) {
-			storyId = story.id;
-		} else {
-			const comment = await getCommentById(db, itemId);
-			if (!comment) {
-				throw error(404, 'Not found');
-			}
-			storyId = comment.story_id;
-		}
-
+		const storyId = await resolveStoryId(db, itemId);
 		const parentIdNum = parentId ? parseInt(parentId, 10) : null;
 
 		await db

--- a/src/routes/item/[id]/+page.server.ts
+++ b/src/routes/item/[id]/+page.server.ts
@@ -1,5 +1,5 @@
 import type { PageServerLoad, Actions } from './$types';
-import { getDB, getStoryById, getCommentsByStoryId, getCommentById, getVotedCommentIds, hasVoted } from '$lib/server/db';
+import { getDB, getStoryById, getCommentsByStoryId, getCommentById, getChildComments, getVotedCommentIds, hasVoted } from '$lib/server/db';
 import { error, fail, redirect } from '@sveltejs/kit';
 
 export const load: PageServerLoad = async ({ params, platform, locals }) => {
@@ -7,32 +7,63 @@ export const load: PageServerLoad = async ({ params, platform, locals }) => {
 	const id = parseInt(params.id, 10);
 
 	if (isNaN(id)) {
-		throw error(404, 'Story not found');
+		throw error(404, 'Not found');
 	}
 
+	// Try story first
 	const story = await getStoryById(db, id);
-	if (!story) {
-		throw error(404, 'Story not found');
+	if (story) {
+		const comments = await getCommentsByStoryId(db, id);
+
+		let storyVoted = false;
+		let votedCommentIds: Set<number> = new Set();
+
+		if (locals.user) {
+			storyVoted = await hasVoted(db, locals.user.id, id, 'story');
+			votedCommentIds = await getVotedCommentIds(
+				db,
+				locals.user.id,
+				comments.map((c) => c.id)
+			);
+		}
+
+		return {
+			mode: 'story' as const,
+			story,
+			comments,
+			storyVoted,
+			votedCommentIds: Array.from(votedCommentIds)
+		};
 	}
 
-	const comments = await getCommentsByStoryId(db, id);
+	// Not a story — try comment
+	const comment = await getCommentById(db, id);
+	if (!comment) {
+		throw error(404, 'Not found');
+	}
 
-	let storyVoted = false;
+	const parentStory = await getStoryById(db, comment.story_id);
+	if (!parentStory) {
+		throw error(404, 'Parent story not found');
+	}
+
+	const childComments = await getChildComments(db, comment.id, comment.story_id);
+
+	let commentVoted = false;
 	let votedCommentIds: Set<number> = new Set();
 
 	if (locals.user) {
-		storyVoted = await hasVoted(db, locals.user.id, id, 'story');
-		votedCommentIds = await getVotedCommentIds(
-			db,
-			locals.user.id,
-			comments.map((c) => c.id)
-		);
+		commentVoted = await hasVoted(db, locals.user.id, comment.id, 'comment');
+		const allCommentIds = [comment.id, ...childComments.map((c) => c.id)];
+		votedCommentIds = await getVotedCommentIds(db, locals.user.id, allCommentIds);
 	}
 
 	return {
-		story,
-		comments,
-		storyVoted,
+		mode: 'comment' as const,
+		targetComment: comment,
+		parentStory,
+		comments: childComments,
+		commentVoted,
 		votedCommentIds: Array.from(votedCommentIds)
 	};
 };
@@ -47,10 +78,23 @@ export const actions: Actions = {
 		const formData = await request.formData();
 		const text = (formData.get('text') as string)?.trim();
 		const parentId = formData.get('parent_id') as string | null;
-		const storyId = parseInt(params.id, 10);
+		const itemId = parseInt(params.id, 10);
 
 		if (!text) {
 			return fail(400, { error: 'Comment text is required' });
+		}
+
+		// Determine story_id: if this page is a comment permalink, use its story_id
+		let storyId: number;
+		const story = await getStoryById(db, itemId);
+		if (story) {
+			storyId = story.id;
+		} else {
+			const comment = await getCommentById(db, itemId);
+			if (!comment) {
+				throw error(404, 'Not found');
+			}
+			storyId = comment.story_id;
 		}
 
 		const parentIdNum = parentId ? parseInt(parentId, 10) : null;

--- a/src/routes/item/[id]/+page.svelte
+++ b/src/routes/item/[id]/+page.svelte
@@ -11,6 +11,8 @@
 	let replyTo = $state<number | null>(null);
 	let editingStory = $state(false);
 	let editingCommentId = $state<number | null>(null);
+	let localTargetCommentVoted = $state<boolean | null>(null);
+	let localTargetCommentPoints = $state<number | null>(null);
 
 	function canEdit(createdAt: string, userId: number): boolean {
 		if (!data.user || data.user.id !== userId) return false;
@@ -18,8 +20,8 @@
 		return elapsed < 2 * 60 * 60 * 1000;
 	}
 
-	let storyVoted = $derived(localStoryVoted ?? data.storyVoted);
-	let storyPoints = $derived(localStoryPoints ?? data.story.points);
+	let storyVoted = $derived(localStoryVoted ?? (data.mode === 'story' ? data.storyVoted : false));
+	let storyPoints = $derived(localStoryPoints ?? (data.mode === 'story' ? data.story.points : 0));
 	let votedCommentIdsFromServer = $derived(new Set(data.votedCommentIds));
 
 	function getVotedCommentIds(): Set<number> {
@@ -29,6 +31,13 @@
 	function getCommentPoints(comment: { id: number; points: number }): number {
 		return localCommentPoints[comment.id] ?? comment.points;
 	}
+
+	let targetCommentVoted = $derived(
+		localTargetCommentVoted ?? (data.mode === 'comment' ? getVotedCommentIds().has(data.targetComment.id) : false)
+	);
+	let targetCommentPoints = $derived(
+		localTargetCommentPoints ?? (data.mode === 'comment' ? data.targetComment.points : 0)
+	);
 
 	interface CommentNode {
 		id: number;
@@ -44,7 +53,8 @@
 	}
 
 	function buildCommentTree(
-		comments: typeof data.comments
+		comments: typeof data.comments,
+		rootParentId?: number
 	): CommentNode[] {
 		const map = new Map<number, CommentNode>();
 		const roots: CommentNode[] = [];
@@ -86,6 +96,7 @@
 			window.location.href = '/login';
 			return;
 		}
+		if (data.mode !== 'story') return;
 		const res = await fetch('/api/vote', {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
@@ -95,6 +106,32 @@
 			const result: { voted: boolean; points: number } = await res.json();
 			localStoryPoints = result.points;
 			localStoryVoted = result.voted;
+		}
+	}
+
+	async function voteTargetComment() {
+		if (!data.user) {
+			window.location.href = '/login';
+			return;
+		}
+		if (data.mode !== 'comment') return;
+		const res = await fetch('/api/vote', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ itemId: data.targetComment.id, itemType: 'comment' })
+		});
+		if (res.ok) {
+			const result: { voted: boolean; points: number } = await res.json();
+			localTargetCommentPoints = result.points;
+			localTargetCommentVoted = result.voted;
+			// Also update in the voted set
+			const next = new Set(getVotedCommentIds());
+			if (result.voted) {
+				next.add(data.targetComment.id);
+			} else {
+				next.delete(data.targetComment.id);
+			}
+			localVotedCommentIds = next;
 		}
 	}
 
@@ -126,182 +163,351 @@
 	}
 </script>
 
-<div class="item-detail" style="padding-left: 40px;">
-	<div style="display: flex; align-items: baseline;">
-		<span class="story-vote" style="margin-right: 4px;">
-			<button
-				class="upvote"
-				class:voted={storyVoted}
-				onclick={voteStory}
-				aria-label="upvote"
-			>
-				&#9650;
-			</button>
-		</span>
-		<span class="item-title">
-			{#if data.story.url}
-				<a href={data.story.url}>{data.story.title}</a>
-				<span class="item-domain">({extractDomain(data.story.url)})</span>
+{#if data.mode === 'comment'}
+	{@const comment = data.targetComment}
+	{@const parentStory = data.parentStory}
+	<div class="item-detail" style="padding-left: 40px;">
+		<div class="comment-head">
+			<span class="comment-vote">
+				<button
+					class="upvote"
+					class:voted={targetCommentVoted}
+					onclick={voteTargetComment}
+					aria-label="upvote comment"
+				>
+					&#9650;
+				</button>
+			</span>
+			<a href="/user/{comment.username}">{comment.username}</a>
+			<a href="/item/{comment.id}">{timeAgo(comment.created_at)}</a>
+			{#if comment.parent_id}
+				| <a href="/item/{comment.parent_id}" style="color: #828282;">parent</a>
 			{:else}
-				{data.story.title}
+				| <a href="/item/{parentStory.id}" style="color: #828282;">parent</a>
 			{/if}
-		</span>
-	</div>
-
-	<div class="item-meta" style="padding-left: 18px;">
-		{storyPoints} point{storyPoints !== 1 ? 's' : ''} by
-		<a href="/user/{data.story.username}">{data.story.username}</a>
-		{timeAgo(data.story.created_at)}
-		{#if canEdit(data.story.created_at, data.story.user_id)}
-			| <a
-				href="#edit"
-				onclick={(e) => {
-					e.preventDefault();
-					editingStory = true;
-				}}>edit</a>
-		{/if}
-	</div>
-
-	{#if editingStory}
-		<div class="comment-form" style="padding-left: 18px;">
-			<form method="POST" action="?/editStory" use:enhance={() => {
-				return async ({ update }) => {
-					editingStory = false;
-					await update();
-					await invalidateAll();
-				};
-			}}>
-				<table style="border-spacing: 0;">
-					<tbody>
-						<tr>
-							<td style="color: #828282; text-align: right; padding: 2px 5px; vertical-align: top;">title:</td>
-							<td style="padding: 2px 5px;"><input type="text" name="title" value={data.story.title} style="font-family: monospace; font-size: 9pt; width: 300px;" /></td>
-						</tr>
-						<tr>
-							<td style="color: #828282; text-align: right; padding: 2px 5px; vertical-align: top;">text:</td>
-							<td style="padding: 2px 5px;"><textarea name="text" rows="6" cols="60">{data.story.text ?? ''}</textarea></td>
-						</tr>
-					</tbody>
-				</table>
-				<button type="submit">update</button>
-				<a
-					href="#cancel"
+			| on: <a href="/item/{parentStory.id}">{parentStory.title}</a>
+			{#if canEdit(comment.created_at, comment.user_id)}
+				| <a
+					href="#edit"
 					onclick={(e) => {
 						e.preventDefault();
-						editingStory = false;
-					}}
-					style="margin-left: 8px; font-size: 7pt; color: #828282;">cancel</a>
-			</form>
+						editingCommentId = comment.id;
+					}}>edit</a>
+			{/if}
 		</div>
-	{:else if data.story.text}
-		<div class="item-text" style="padding-left: 18px;">
-			{#each data.story.text.split('\n') as paragraph}
-				{#if paragraph.trim()}
-					<p>{paragraph}</p>
-				{/if}
-			{/each}
-		</div>
-	{/if}
+		{#if editingCommentId === comment.id}
+			<div class="comment-form" style="padding-left: 14px;">
+				<form method="POST" action="?/editComment" use:enhance={() => {
+					return async ({ update }) => {
+						editingCommentId = null;
+						await update();
+						await invalidateAll();
+					};
+				}}>
+					<input type="hidden" name="comment_id" value={comment.id} />
+					<textarea name="text" rows="4" cols="60">{comment.text}</textarea>
+					<br />
+					<button type="submit">update</button>
+					<a
+						href="#cancel"
+						onclick={(e) => {
+							e.preventDefault();
+							editingCommentId = null;
+						}}
+						style="margin-left: 8px; font-size: 7pt; color: #828282;">cancel</a>
+				</form>
+			</div>
+		{:else}
+			<div class="comment-text" style="padding-left: 14px;">
+				{#each comment.text.split('\n') as paragraph}
+					{#if paragraph.trim()}
+						<p>{paragraph}</p>
+					{/if}
+				{/each}
+			</div>
+		{/if}
 
-	{#if data.user}
-		<div class="comment-form" style="padding-left: 18px;">
-			<form method="POST" action="?/comment" use:enhance={() => {
-				return async ({ update }) => {
-					await update();
-					await invalidateAll();
-				};
-			}}>
-				<textarea name="text" rows="6" cols="60"></textarea>
-				<br />
-				<button type="submit">add comment</button>
-			</form>
-		</div>
-	{/if}
+		{#if data.user}
+			<div class="comment-form" style="padding-left: 14px;">
+				<form method="POST" action="?/comment" use:enhance={() => {
+					return async ({ update }) => {
+						await update();
+						await invalidateAll();
+					};
+				}}>
+					<input type="hidden" name="parent_id" value={comment.id} />
+					<textarea name="text" rows="6" cols="60"></textarea>
+					<br />
+					<button type="submit">reply</button>
+				</form>
+			</div>
+		{/if}
 
-	<div class="comments-section" style="padding-left: 0;">
-		{#each commentTree as comment}
-			<div class="comment-item" style="padding-left: {comment.depth * 40}px;">
-				<div class="comment-head">
-					<span class="comment-vote">
-						<button
-							class="upvote"
-							class:voted={getVotedCommentIds().has(comment.id)}
-							onclick={() => voteComment(comment.id)}
-							aria-label="upvote comment"
-						>
-							&#9650;
-						</button>
-					</span>
-					<a href="/user/{comment.username}">{comment.username}</a>
-					{timeAgo(comment.created_at)}
-				</div>
-				{#if editingCommentId === comment.id}
-					<div class="comment-form" style="padding-left: 14px;">
-						<form method="POST" action="?/editComment" use:enhance={() => {
-							return async ({ update }) => {
-								editingCommentId = null;
-								await update();
-								await invalidateAll();
-							};
-						}}>
-							<input type="hidden" name="comment_id" value={comment.id} />
-							<textarea name="text" rows="4" cols="60">{comment.text}</textarea>
-							<br />
-							<button type="submit">update</button>
-							<a
-								href="#cancel"
-								onclick={(e) => {
-									e.preventDefault();
-									editingCommentId = null;
-								}}
-								style="margin-left: 8px; font-size: 7pt; color: #828282;">cancel</a>
-						</form>
+		<div class="comments-section" style="padding-left: 0;">
+			{#each commentTree as child}
+				<div class="comment-item" style="padding-left: {child.depth * 40}px;">
+					<div class="comment-head">
+						<span class="comment-vote">
+							<button
+								class="upvote"
+								class:voted={getVotedCommentIds().has(child.id)}
+								onclick={() => voteComment(child.id)}
+								aria-label="upvote comment"
+							>
+								&#9650;
+							</button>
+						</span>
+						<a href="/user/{child.username}">{child.username}</a>
+						<a href="/item/{child.id}">{timeAgo(child.created_at)}</a>
 					</div>
-				{:else}
-					<div class="comment-text" style="padding-left: 14px;">
-						{#each comment.text.split('\n') as paragraph}
-							{#if paragraph.trim()}
-								<p>{paragraph}</p>
-							{/if}
-						{/each}
-					</div>
-				{/if}
-				{#if data.user}
-					<div class="comment-reply" style="padding-left: 14px;">
-						<a
-							href="#reply"
-							onclick={(e) => {
-								e.preventDefault();
-								toggleReply(comment.id);
-							}}>reply</a
-						>
-						{#if canEdit(comment.created_at, comment.user_id)}
-							| <a
-								href="#edit"
-								onclick={(e) => {
-									e.preventDefault();
-									editingCommentId = comment.id;
-								}}>edit</a>
-						{/if}
-					</div>
-					{#if replyTo === comment.id}
+					{#if editingCommentId === child.id}
 						<div class="comment-form" style="padding-left: 14px;">
-							<form method="POST" action="?/comment" use:enhance={() => {
+							<form method="POST" action="?/editComment" use:enhance={() => {
 								return async ({ update }) => {
-									replyTo = null;
+									editingCommentId = null;
 									await update();
 									await invalidateAll();
 								};
 							}}>
-								<input type="hidden" name="parent_id" value={comment.id} />
-								<textarea name="text" rows="4" cols="60"></textarea>
+								<input type="hidden" name="comment_id" value={child.id} />
+								<textarea name="text" rows="4" cols="60">{child.text}</textarea>
 								<br />
-								<button type="submit">reply</button>
+								<button type="submit">update</button>
+								<a
+									href="#cancel"
+									onclick={(e) => {
+										e.preventDefault();
+										editingCommentId = null;
+									}}
+									style="margin-left: 8px; font-size: 7pt; color: #828282;">cancel</a>
 							</form>
 						</div>
+					{:else}
+						<div class="comment-text" style="padding-left: 14px;">
+							{#each child.text.split('\n') as paragraph}
+								{#if paragraph.trim()}
+									<p>{paragraph}</p>
+								{/if}
+							{/each}
+						</div>
 					{/if}
-				{/if}
-			</div>
-		{/each}
+					{#if data.user}
+						<div class="comment-reply" style="padding-left: 14px;">
+							<a
+								href="#reply"
+								onclick={(e) => {
+									e.preventDefault();
+									toggleReply(child.id);
+								}}>reply</a
+							>
+							{#if canEdit(child.created_at, child.user_id)}
+								| <a
+									href="#edit"
+									onclick={(e) => {
+										e.preventDefault();
+										editingCommentId = child.id;
+									}}>edit</a>
+							{/if}
+						</div>
+						{#if replyTo === child.id}
+							<div class="comment-form" style="padding-left: 14px;">
+								<form method="POST" action="?/comment" use:enhance={() => {
+									return async ({ update }) => {
+										replyTo = null;
+										await update();
+										await invalidateAll();
+									};
+								}}>
+									<input type="hidden" name="parent_id" value={child.id} />
+									<textarea name="text" rows="4" cols="60"></textarea>
+									<br />
+									<button type="submit">reply</button>
+								</form>
+							</div>
+						{/if}
+					{/if}
+				</div>
+			{/each}
+		</div>
 	</div>
-</div>
+{:else}
+	<div class="item-detail" style="padding-left: 40px;">
+		<div style="display: flex; align-items: baseline;">
+			<span class="story-vote" style="margin-right: 4px;">
+				<button
+					class="upvote"
+					class:voted={storyVoted}
+					onclick={voteStory}
+					aria-label="upvote"
+				>
+					&#9650;
+				</button>
+			</span>
+			<span class="item-title">
+				{#if data.story.url}
+					<a href={data.story.url}>{data.story.title}</a>
+					<span class="item-domain">({extractDomain(data.story.url)})</span>
+				{:else}
+					{data.story.title}
+				{/if}
+			</span>
+		</div>
+
+		<div class="item-meta" style="padding-left: 18px;">
+			{storyPoints} point{storyPoints !== 1 ? 's' : ''} by
+			<a href="/user/{data.story.username}">{data.story.username}</a>
+			{timeAgo(data.story.created_at)}
+			{#if canEdit(data.story.created_at, data.story.user_id)}
+				| <a
+					href="#edit"
+					onclick={(e) => {
+						e.preventDefault();
+						editingStory = true;
+					}}>edit</a>
+			{/if}
+		</div>
+
+		{#if editingStory}
+			<div class="comment-form" style="padding-left: 18px;">
+				<form method="POST" action="?/editStory" use:enhance={() => {
+					return async ({ update }) => {
+						editingStory = false;
+						await update();
+						await invalidateAll();
+					};
+				}}>
+					<table style="border-spacing: 0;">
+						<tbody>
+							<tr>
+								<td style="color: #828282; text-align: right; padding: 2px 5px; vertical-align: top;">title:</td>
+								<td style="padding: 2px 5px;"><input type="text" name="title" value={data.story.title} style="font-family: monospace; font-size: 9pt; width: 300px;" /></td>
+							</tr>
+							<tr>
+								<td style="color: #828282; text-align: right; padding: 2px 5px; vertical-align: top;">text:</td>
+								<td style="padding: 2px 5px;"><textarea name="text" rows="6" cols="60">{data.story.text ?? ''}</textarea></td>
+							</tr>
+						</tbody>
+					</table>
+					<button type="submit">update</button>
+					<a
+						href="#cancel"
+						onclick={(e) => {
+							e.preventDefault();
+							editingStory = false;
+						}}
+						style="margin-left: 8px; font-size: 7pt; color: #828282;">cancel</a>
+				</form>
+			</div>
+		{:else if data.story.text}
+			<div class="item-text" style="padding-left: 18px;">
+				{#each data.story.text.split('\n') as paragraph}
+					{#if paragraph.trim()}
+						<p>{paragraph}</p>
+					{/if}
+				{/each}
+			</div>
+		{/if}
+
+		{#if data.user}
+			<div class="comment-form" style="padding-left: 18px;">
+				<form method="POST" action="?/comment" use:enhance={() => {
+					return async ({ update }) => {
+						await update();
+						await invalidateAll();
+					};
+				}}>
+					<textarea name="text" rows="6" cols="60"></textarea>
+					<br />
+					<button type="submit">add comment</button>
+				</form>
+			</div>
+		{/if}
+
+		<div class="comments-section" style="padding-left: 0;">
+			{#each commentTree as comment}
+				<div class="comment-item" style="padding-left: {comment.depth * 40}px;">
+					<div class="comment-head">
+						<span class="comment-vote">
+							<button
+								class="upvote"
+								class:voted={getVotedCommentIds().has(comment.id)}
+								onclick={() => voteComment(comment.id)}
+								aria-label="upvote comment"
+							>
+								&#9650;
+							</button>
+						</span>
+						<a href="/user/{comment.username}">{comment.username}</a>
+						<a href="/item/{comment.id}">{timeAgo(comment.created_at)}</a>
+					</div>
+					{#if editingCommentId === comment.id}
+						<div class="comment-form" style="padding-left: 14px;">
+							<form method="POST" action="?/editComment" use:enhance={() => {
+								return async ({ update }) => {
+									editingCommentId = null;
+									await update();
+									await invalidateAll();
+								};
+							}}>
+								<input type="hidden" name="comment_id" value={comment.id} />
+								<textarea name="text" rows="4" cols="60">{comment.text}</textarea>
+								<br />
+								<button type="submit">update</button>
+								<a
+									href="#cancel"
+									onclick={(e) => {
+										e.preventDefault();
+										editingCommentId = null;
+									}}
+									style="margin-left: 8px; font-size: 7pt; color: #828282;">cancel</a>
+							</form>
+						</div>
+					{:else}
+						<div class="comment-text" style="padding-left: 14px;">
+							{#each comment.text.split('\n') as paragraph}
+								{#if paragraph.trim()}
+									<p>{paragraph}</p>
+								{/if}
+							{/each}
+						</div>
+					{/if}
+					{#if data.user}
+						<div class="comment-reply" style="padding-left: 14px;">
+							<a
+								href="#reply"
+								onclick={(e) => {
+									e.preventDefault();
+									toggleReply(comment.id);
+								}}>reply</a
+							>
+							{#if canEdit(comment.created_at, comment.user_id)}
+								| <a
+									href="#edit"
+									onclick={(e) => {
+										e.preventDefault();
+										editingCommentId = comment.id;
+									}}>edit</a>
+							{/if}
+						</div>
+						{#if replyTo === comment.id}
+							<div class="comment-form" style="padding-left: 14px;">
+								<form method="POST" action="?/comment" use:enhance={() => {
+									return async ({ update }) => {
+										replyTo = null;
+										await update();
+										await invalidateAll();
+									};
+								}}>
+									<input type="hidden" name="parent_id" value={comment.id} />
+									<textarea name="text" rows="4" cols="60"></textarea>
+									<br />
+									<button type="submit">reply</button>
+								</form>
+							</div>
+						{/if}
+					{/if}
+				</div>
+			{/each}
+		</div>
+	</div>
+{/if}

--- a/src/routes/item/[id]/+page.svelte
+++ b/src/routes/item/[id]/+page.svelte
@@ -53,8 +53,7 @@
 	}
 
 	function buildCommentTree(
-		comments: typeof data.comments,
-		rootParentId?: number
+		comments: typeof data.comments
 	): CommentNode[] {
 		const map = new Map<number, CommentNode>();
 		const roots: CommentNode[] = [];

--- a/src/routes/user/[id]/comments/+page.svelte
+++ b/src/routes/user/[id]/comments/+page.svelte
@@ -56,9 +56,9 @@
 					</button>
 				</span>
 				<a href="/user/{comment.username}">{comment.username}</a>
-				<a href="/item/{comment.story_id}">{timeAgo(comment.created_at)}</a>
-				| <a href="/item/{comment.story_id}" style="color: #828282;">parent</a>
-				| <a href="/item/{comment.story_id}" style="color: #828282;">context</a>
+				<a href="/item/{comment.id}">{timeAgo(comment.created_at)}</a>
+				| <a href="/item/{comment.parent_id ?? comment.story_id}" style="color: #828282;">parent</a>
+				| <a href="/item/{comment.id}" style="color: #828282;">context</a>
 				| on: <a href="/item/{comment.story_id}">{comment.story_title}</a>
 			</div>
 			<div class="comment-text" style="padding-left: 14px;">


### PR DESCRIPTION
## 関連 Issue
closes #16

## 変更内容
- `/item/[id]` でストーリーだけでなくコメントにも対応（2段階ルックアップ）
- コメントパーマリンクページ: コメント本文 + 子スレッド + parent/on:リンク + 投票・返信・編集
- ストーリーページ・コメントパーマリンクページ両方で、タイムスタンプをパーマリンクリンクに変更
- `/user/[id]/comments` の parent/context リンクを正しいURLに修正
- `getChildComments()` DB関数追加
- docs/spec.md, docs/architecture.md 更新