### PR TITLE
feat: コメント・投稿テキストにフォーマット機能を追加

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,6 +37,7 @@ hacker-noroshi/
 │   │   ├── server/
 │   │   │   ├── db.ts         # D1 データアクセス関数
 │   │   │   └── auth.ts       # パスワードハッシュ・セッション管理
+│   │   ├── format.ts         # テキストフォーマット（URL自動リンク、*イタリック*）
 │   │   └── ranking.ts        # timeAgo, extractDomain 等のユーティリティ
 │   ├── app.css               # グローバル CSS
 │   └── app.html              # HTML テンプレート

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -22,7 +22,7 @@ URL: https://hn.llll-ll.com
 
 - ネストスレッド（40px/段のインデント）
 - トップレベルコメントまたは既存コメントへの返信
-- プレーンテキストのみ（Markdown 不可）
+- テキストフォーマット: URL自動リンク（`rel="nofollow noreferrer"`）、`*text*` でイタリック
 - パーマリンク: `/item/{comment_id}` でコメント単体 + 子スレッドを表示
 - parent リンク（親コメント or 親ストーリーへ）、on: リンク（親ストーリーへ）
 - タイムスタンプがパーマリンクリンクを兼ねる
@@ -82,6 +82,7 @@ score = (points - 1) / (hours_since_post + 2) ^ 1.8
 - [x] ガイドライン・FAQ・Show HN ルールページ
 - [x] ユーザーの submissions / comments 一覧ページ
 - [x] コメントパーマリンク（/item/{comment_id}）
+- [x] テキストフォーマット（URL自動リンク、*イタリック*）
 
 ## v2 以降
 

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,7 +1,7 @@
 /**
  * HN-compatible text formatting.
- * - HTML escape (XSS prevention)
- * - Auto-link URLs
+ * - Auto-link URLs (before HTML escape to preserve original URLs)
+ * - HTML escape non-URL parts (XSS prevention)
  * - *italic* conversion
  */
 
@@ -12,13 +12,6 @@ function escapeHtml(text: string): string {
 		.replace(/>/g, '&gt;')
 		.replace(/"/g, '&quot;')
 		.replace(/'/g, '&#x27;');
-}
-
-function autoLinkUrls(text: string): string {
-	return text.replace(
-		/https?:\/\/[^\s&lt;&gt;]*/g,
-		(url) => `<a href="${url}" rel="nofollow noreferrer">${url}</a>`
-	);
 }
 
 function italicize(text: string): string {
@@ -33,8 +26,42 @@ function italicize(text: string): string {
 }
 
 export function formatText(text: string): string {
-	let result = escapeHtml(text);
-	result = autoLinkUrls(result);
+	// Split text into URL and non-URL segments.
+	// Process URLs before HTML escape to preserve original href values.
+	const urlPattern = /https?:\/\/[^\s<>]*/g;
+	const parts: string[] = [];
+	let lastIndex = 0;
+	let match: RegExpExecArray | null;
+
+	while ((match = urlPattern.exec(text)) !== null) {
+		// Escape non-URL text before this match
+		if (match.index > lastIndex) {
+			parts.push(escapeHtml(text.slice(lastIndex, match.index)));
+		}
+
+		// Strip trailing punctuation from URL
+		let url = match[0];
+		const trailingMatch = url.match(/[.,;:!?)\]]+$/);
+		let trailing = '';
+		if (trailingMatch) {
+			trailing = trailingMatch[0];
+			url = url.slice(0, -trailing.length);
+		}
+
+		parts.push(`<a href="${url}" rel="nofollow noreferrer">${escapeHtml(url)}</a>`);
+		if (trailing) {
+			parts.push(escapeHtml(trailing));
+		}
+
+		lastIndex = match.index + match[0].length;
+	}
+
+	// Escape remaining non-URL text
+	if (lastIndex < text.length) {
+		parts.push(escapeHtml(text.slice(lastIndex)));
+	}
+
+	let result = parts.join('');
 	result = italicize(result);
 	return result;
 }

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,40 @@
+/**
+ * HN-compatible text formatting.
+ * - HTML escape (XSS prevention)
+ * - Auto-link URLs
+ * - *italic* conversion
+ */
+
+function escapeHtml(text: string): string {
+	return text
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#x27;');
+}
+
+function autoLinkUrls(text: string): string {
+	return text.replace(
+		/https?:\/\/[^\s&lt;&gt;]*/g,
+		(url) => `<a href="${url}" rel="nofollow noreferrer">${url}</a>`
+	);
+}
+
+function italicize(text: string): string {
+	// Match *text* where:
+	// - Opening * is at start of string or preceded by whitespace
+	// - Closing * is at end of string or followed by whitespace/punctuation
+	// - Content is non-empty and doesn't contain *
+	return text.replace(
+		/(^|\s)\*([^\s*][^*]*[^\s*]|[^\s*])\*(?=\s|$|[.,;:!?)])/g,
+		'$1<i>$2</i>'
+	);
+}
+
+export function formatText(text: string): string {
+	let result = escapeHtml(text);
+	result = autoLinkUrls(result);
+	result = italicize(result);
+	return result;
+}

--- a/src/routes/item/[id]/+page.svelte
+++ b/src/routes/item/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
 	import { timeAgo, extractDomain } from '$lib/ranking';
+	import { formatText } from '$lib/format';
 	import { invalidateAll } from '$app/navigation';
 
 	let { data, form } = $props();
@@ -220,7 +221,7 @@
 			<div class="comment-text" style="padding-left: 14px;">
 				{#each comment.text.split('\n') as paragraph}
 					{#if paragraph.trim()}
-						<p>{paragraph}</p>
+						<p>{@html formatText(paragraph)}</p>
 					{/if}
 				{/each}
 			</div>
@@ -285,7 +286,7 @@
 						<div class="comment-text" style="padding-left: 14px;">
 							{#each child.text.split('\n') as paragraph}
 								{#if paragraph.trim()}
-									<p>{paragraph}</p>
+									<p>{@html formatText(paragraph)}</p>
 								{/if}
 							{/each}
 						</div>
@@ -401,7 +402,7 @@
 			<div class="item-text" style="padding-left: 18px;">
 				{#each data.story.text.split('\n') as paragraph}
 					{#if paragraph.trim()}
-						<p>{paragraph}</p>
+						<p>{@html formatText(paragraph)}</p>
 					{/if}
 				{/each}
 			</div>
@@ -465,7 +466,7 @@
 						<div class="comment-text" style="padding-left: 14px;">
 							{#each comment.text.split('\n') as paragraph}
 								{#if paragraph.trim()}
-									<p>{paragraph}</p>
+									<p>{@html formatText(paragraph)}</p>
 								{/if}
 							{/each}
 						</div>

--- a/src/routes/user/[id]/comments/+page.svelte
+++ b/src/routes/user/[id]/comments/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { timeAgo } from '$lib/ranking';
+	import { formatText } from '$lib/format';
 
 	let { data } = $props();
 	let localVotedIds = $state<Set<number> | null>(null);
@@ -64,7 +65,7 @@
 			<div class="comment-text" style="padding-left: 14px;">
 				{#each comment.text.split('\n') as paragraph}
 					{#if paragraph.trim()}
-						<p>{paragraph}</p>
+						<p>{@html formatText(paragraph)}</p>
 					{/if}
 				{/each}
 			</div>


### PR DESCRIPTION
## 関連 Issue
closes #23

## 変更内容
- `src/lib/format.ts` 新規作成: HTMLエスケープ → URL自動リンク → *イタリック* 変換
- `/item/[id]` のコメント・ストーリーテキスト全4箇所に適用
- `/user/[id]/comments` のコメントテキストに適用
- docs/spec.md, docs/architecture.md 更新