### PR TITLE
fix: ログインページにサインアップフォームを統合

### DIFF
--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -1,6 +1,6 @@
 import type { PageServerLoad, Actions } from './$types';
 import { getDB, getUserByUsername } from '$lib/server/db';
-import { verifyPassword, createSession } from '$lib/server/auth';
+import { verifyPassword, hashPassword, createSession } from '$lib/server/auth';
 import { fail, redirect } from '@sveltejs/kit';
 
 export const load: PageServerLoad = async ({ locals }) => {
@@ -11,27 +11,78 @@ export const load: PageServerLoad = async ({ locals }) => {
 };
 
 export const actions: Actions = {
-	default: async ({ request, platform, cookies }) => {
+	login: async ({ request, platform, cookies }) => {
 		const db = getDB(platform);
 		const formData = await request.formData();
 		const username = (formData.get('username') as string)?.trim();
 		const password = formData.get('password') as string;
 
 		if (!username || !password) {
-			return fail(400, { error: 'Username and password are required', username });
+			return fail(400, { loginError: 'Username and password are required', loginUsername: username });
 		}
 
 		const user = await getUserByUsername(db, username);
 		if (!user) {
-			return fail(400, { error: 'Bad login', username });
+			return fail(400, { loginError: 'Bad login', loginUsername: username });
 		}
 
 		const valid = await verifyPassword(password, user.password_hash);
 		if (!valid) {
-			return fail(400, { error: 'Bad login', username });
+			return fail(400, { loginError: 'Bad login', loginUsername: username });
 		}
 
 		const sessionId = await createSession(db, user.id);
+
+		cookies.set('session', sessionId, {
+			path: '/',
+			httpOnly: true,
+			sameSite: 'lax',
+			secure: false,
+			maxAge: 30 * 24 * 60 * 60
+		});
+
+		throw redirect(302, '/');
+	},
+
+	signup: async ({ request, platform, cookies }) => {
+		const db = getDB(platform);
+		const formData = await request.formData();
+		const username = (formData.get('username') as string)?.trim();
+		const password = formData.get('password') as string;
+
+		if (!username || !password) {
+			return fail(400, { signupError: 'Username and password are required', signupUsername: username });
+		}
+
+		if (username.length < 3 || username.length > 15) {
+			return fail(400, { signupError: 'Username must be between 3 and 15 characters', signupUsername: username });
+		}
+
+		if (!/^[a-zA-Z0-9_-]+$/.test(username)) {
+			return fail(400, {
+				signupError: 'Username can only contain letters, numbers, underscores, and hyphens',
+				signupUsername: username
+			});
+		}
+
+		if (password.length < 8) {
+			return fail(400, { signupError: 'Password must be at least 8 characters', signupUsername: username });
+		}
+
+		const existing = await getUserByUsername(db, username);
+		if (existing) {
+			return fail(400, { signupError: 'That username is taken', signupUsername: username });
+		}
+
+		const passwordHash = await hashPassword(password);
+
+		const result = await db
+			.prepare('INSERT INTO users (username, password_hash) VALUES (?, ?)')
+			.bind(username, passwordHash)
+			.run();
+
+		const userId = result.meta.last_row_id;
+		const sessionId = await createSession(db, userId as number);
 
 		cookies.set('session', sessionId, {
 			path: '/',

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -9,16 +9,17 @@
 </svelte:head>
 
 <div class="hn-form">
-	{#if form?.error}
-		<div class="form-error">{form.error}</div>
+	<b>Login</b>
+	{#if form?.loginError}
+		<div class="form-error">{form.loginError}</div>
 	{/if}
 
-	<form method="POST" use:enhance>
+	<form method="POST" action="?/login" use:enhance>
 		<table>
 			<tbody>
 				<tr>
 					<td>username:</td>
-					<td><input type="text" name="username" value={form?.username ?? ''} autocomplete="username" /></td>
+					<td><input type="text" name="username" value={form?.loginUsername ?? ''} autocomplete="username" /></td>
 				</tr>
 				<tr>
 					<td>password:</td>
@@ -30,7 +31,34 @@
 		<button type="submit">login</button>
 	</form>
 
+	<br />
+	<hr style="border: 0; border-top: 1pt solid #e0e0e0;" />
+	<br />
+
+	<b>Create Account</b>
+	{#if form?.signupError}
+		<div class="form-error">{form.signupError}</div>
+	{/if}
+
+	<form method="POST" action="?/signup" use:enhance>
+		<table>
+			<tbody>
+				<tr>
+					<td>username:</td>
+					<td><input type="text" name="username" value={form?.signupUsername ?? ''} autocomplete="username" /></td>
+				</tr>
+				<tr>
+					<td>password:</td>
+					<td><input type="password" name="password" autocomplete="new-password" /></td>
+				</tr>
+			</tbody>
+		</table>
+		<br />
+		<button type="submit">create account</button>
+	</form>
+
 	<div class="form-note">
-		<a href="/signup" style="color: #828282;">Create Account</a>
+		Usernames can only contain letters, digits, underscores, and hyphens, and should be between 3 and 15 characters long.
+		Passwords should be at least 8 characters.
 	</div>
 </div>

--- a/src/routes/signup/+page.server.ts
+++ b/src/routes/signup/+page.server.ts
@@ -1,64 +1,6 @@
-import type { PageServerLoad, Actions } from './$types';
-import { getDB, getUserByUsername } from '$lib/server/db';
-import { hashPassword, createSession } from '$lib/server/auth';
-import { fail, redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import { redirect } from '@sveltejs/kit';
 
-export const load: PageServerLoad = async ({ locals }) => {
-	if (locals.user) {
-		throw redirect(302, '/');
-	}
-	return {};
-};
-
-export const actions: Actions = {
-	default: async ({ request, platform, cookies }) => {
-		const db = getDB(platform);
-		const formData = await request.formData();
-		const username = (formData.get('username') as string)?.trim();
-		const password = formData.get('password') as string;
-
-		if (!username || !password) {
-			return fail(400, { error: 'Username and password are required', username });
-		}
-
-		if (username.length < 3 || username.length > 15) {
-			return fail(400, { error: 'Username must be between 3 and 15 characters', username });
-		}
-
-		if (!/^[a-zA-Z0-9_-]+$/.test(username)) {
-			return fail(400, {
-				error: 'Username can only contain letters, numbers, underscores, and hyphens',
-				username
-			});
-		}
-
-		if (password.length < 8) {
-			return fail(400, { error: 'Password must be at least 8 characters', username });
-		}
-
-		const existing = await getUserByUsername(db, username);
-		if (existing) {
-			return fail(400, { error: 'That username is taken', username });
-		}
-
-		const passwordHash = await hashPassword(password);
-
-		const result = await db
-			.prepare('INSERT INTO users (username, password_hash) VALUES (?, ?)')
-			.bind(username, passwordHash)
-			.run();
-
-		const userId = result.meta.last_row_id;
-		const sessionId = await createSession(db, userId as number);
-
-		cookies.set('session', sessionId, {
-			path: '/',
-			httpOnly: true,
-			sameSite: 'lax',
-			secure: false,
-			maxAge: 30 * 24 * 60 * 60
-		});
-
-		throw redirect(302, '/');
-	}
+export const load: PageServerLoad = async () => {
+	throw redirect(302, '/login');
 };

--- a/src/routes/signup/+page.svelte
+++ b/src/routes/signup/+page.svelte
@@ -1,37 +1,4 @@
 <script lang="ts">
-	import { enhance } from '$app/forms';
-
-	let { form } = $props();
 </script>
 
-<svelte:head>
-	<title>Create Account | ハッカーのろし</title>
-</svelte:head>
-
-<div class="hn-form">
-	{#if form?.error}
-		<div class="form-error">{form.error}</div>
-	{/if}
-
-	<form method="POST" use:enhance>
-		<table>
-			<tbody>
-				<tr>
-					<td>username:</td>
-					<td><input type="text" name="username" value={form?.username ?? ''} autocomplete="username" /></td>
-				</tr>
-				<tr>
-					<td>password:</td>
-					<td><input type="password" name="password" autocomplete="new-password" /></td>
-				</tr>
-			</tbody>
-		</table>
-		<br />
-		<button type="submit">create account</button>
-	</form>
-
-	<div class="form-note">
-		Usernames can only contain letters, digits, and underscores, and should be between 3 and 15 characters long.
-		Passwords should be at least 8 characters.
-	</div>
-</div>
+<p>Redirecting to login...</p>


### PR DESCRIPTION
## 変更内容
本家HNに合わせて、/login ページにログインとサインアップの両フォームを統合。
- /login: Login フォーム + Create Account フォームを縦に配置
- /signup: /login へリダイレクト（既存リンク互換）
- 各フォームのエラー表示を独立化（loginError / signupError）