### PR TITLE
fix: ヘッダーナビにcommentsリンクを追加

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -16,6 +16,8 @@
 			<nav class="hn-header-nav">
 				<a href="/newest">new</a>
 				<span class="nav-separator">|</span>
+				<a href="/newcomments">comments</a>
+				<span class="nav-separator">|</span>
 				<a href="/ask">ask</a>
 				<span class="nav-separator">|</span>
 				<a href="/show">show</a>


### PR DESCRIPTION
本家HNのヘッダーナビ（new | comments | ask | show | submit）に合わせてcommentsリンクを追加。/newcomments に遷移する。