### PR TITLE
feat: ヘッダーナビにpastリンクを追加し/frontページを実装

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,7 @@ hacker-noroshi/
 │   │   ├── +layout.svelte    # 共通レイアウト（ヘッダー・フッター）
 │   │   ├── +page.svelte      # トップページ（ランキング）
 │   │   ├── newest/           # 新着順
+│   │   ├── front/            # 日付別フロントページ
 │   │   ├── ask/              # Ask HN
 │   │   ├── show/             # Show HN
 │   │   ├── newcomments/      # 全ストーリーの最新コメント一覧

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -118,6 +118,7 @@ hacker-noroshi/
 |---|---|
 | `/` | トップページ（ランキング順、30件/ページ） |
 | `/newest` | 新着順 |
+| `/front` | 日付別フロントページ（?day=YYYY-MM-DD、デフォルト昨日） |
 | `/ask` | Ask HN（type='ask' のみ） |
 | `/show` | Show HN（type='show' のみ） |
 | `/newcomments` | 全ストーリーの最新コメント一覧 |
@@ -141,6 +142,7 @@ hacker-noroshi/
 |---|---|
 | `getDB()` | D1 バインディング取得 |
 | `getStories()` | ストーリー一覧（ランキング or 新着、type フィルタ、ページネーション） |
+| `getFrontPageStories()` | 日付別フロントページ（日付範囲でフィルタ、HNランクスコアでソート） |
 | `getStoryById()` | ストーリー1件取得 |
 | `getCommentsByStoryId()` | コメント一覧（ストーリーID指定） |
 | `getCommentById()` | コメント1件取得（編集時の権限チェック・パーマリンク用） |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -90,6 +90,7 @@ score = (points - 1) / (hours_since_post + 2) ^ 1.8
 - [x] 追加ブラウズページ（/newcomments, /best）
 - [x] ログイン+サインアップ1ページ統合（本家HN準拠）
 - [x] ヘッダーナビに comments リンク追加
+- [x] /front ページ（日付別フロントページ）+ ヘッダーナビに past リンク追加
 
 ## v2 以降
 

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -120,6 +120,37 @@ export async function getStories(
 	return ranked;
 }
 
+export async function getFrontPageStories(
+	db: D1Database,
+	day: string,
+	page: number = 1,
+	limit: number = 30
+): Promise<StoryRow[]> {
+	const offset = (page - 1) * limit;
+	const dayStart = `${day}T00:00:00.000Z`;
+	const dayEnd = `${day}T23:59:59.999Z`;
+
+	const sql = `
+		SELECT s.*, u.username, u.created_at as user_created_at
+		FROM stories s
+		JOIN users u ON s.user_id = u.id
+		WHERE s.created_at >= ? AND s.created_at <= ?
+		ORDER BY s.created_at DESC
+	`;
+	const result = await db.prepare(sql).bind(dayStart, dayEnd).all<StoryRow>();
+
+	const now = Date.now();
+	const ranked = result.results
+		.map((s) => {
+			const hoursAge = (now - new Date(s.created_at).getTime()) / (1000 * 60 * 60);
+			const score = (s.points - 1) / Math.pow(hoursAge + 2, 1.8);
+			return { ...s, _score: score };
+		})
+		.sort((a, b) => b._score - a._score)
+		.slice(offset, offset + limit);
+	return ranked;
+}
+
 export async function getStoryById(db: D1Database, id: number): Promise<StoryRow | null> {
 	const result = await db
 		.prepare(

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -130,14 +130,16 @@ export async function getFrontPageStories(
 	const dayStart = `${day}T00:00:00.000Z`;
 	const dayEnd = `${day}T23:59:59.999Z`;
 
+	const fetchLimit = 500;
 	const sql = `
 		SELECT s.*, u.username, u.created_at as user_created_at
 		FROM stories s
 		JOIN users u ON s.user_id = u.id
 		WHERE s.created_at >= ? AND s.created_at <= ?
 		ORDER BY s.created_at DESC
+		LIMIT ?
 	`;
-	const result = await db.prepare(sql).bind(dayStart, dayEnd).all<StoryRow>();
+	const result = await db.prepare(sql).bind(dayStart, dayEnd, fetchLimit).all<StoryRow>();
 
 	const now = Date.now();
 	const ranked = result.results

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -16,6 +16,8 @@
 			<nav class="hn-header-nav">
 				<a href="/newest">new</a>
 				<span class="nav-separator">|</span>
+				<a href="/front">past</a>
+				<span class="nav-separator">|</span>
 				<a href="/newcomments">comments</a>
 				<span class="nav-separator">|</span>
 				<a href="/ask">ask</a>

--- a/src/routes/front/+page.server.ts
+++ b/src/routes/front/+page.server.ts
@@ -1,0 +1,36 @@
+import type { PageServerLoad } from './$types';
+import { getDB, getFrontPageStories, getVotedStoryIds } from '$lib/server/db';
+
+export const load: PageServerLoad = async ({ url, platform, locals }) => {
+	const db = getDB(platform);
+	const page = parseInt(url.searchParams.get('p') || '1', 10);
+
+	// Default to yesterday UTC
+	const dayParam = url.searchParams.get('day');
+	let day: string;
+	if (dayParam && /^\d{4}-\d{2}-\d{2}$/.test(dayParam)) {
+		day = dayParam;
+	} else {
+		const yesterday = new Date();
+		yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+		day = yesterday.toISOString().slice(0, 10);
+	}
+
+	const stories = await getFrontPageStories(db, day, page, 30);
+
+	let votedIds: Set<number> = new Set();
+	if (locals.user) {
+		votedIds = await getVotedStoryIds(
+			db,
+			locals.user.id,
+			stories.map((s) => s.id)
+		);
+	}
+
+	return {
+		stories,
+		page,
+		day,
+		votedIds: Array.from(votedIds)
+	};
+};

--- a/src/routes/front/+page.svelte
+++ b/src/routes/front/+page.svelte
@@ -69,6 +69,10 @@
 	</span>
 </div>
 
+{#if data.stories.length === 0}
+<div class="front-empty">No stories for this date.</div>
+{/if}
+
 <div class="story-list">
 	{#each data.stories as story, i}
 		<div class="story-item">
@@ -116,7 +120,6 @@
 		padding: 5pt 0;
 		font-size: 7pt;
 		color: #828282;
-		font-family: Verdana, Geneva, sans-serif;
 	}
 
 	.front-nav-label {
@@ -124,6 +127,12 @@
 	}
 
 	.front-nav-links a {
+		color: #828282;
+	}
+
+	.front-empty {
+		padding: 10pt 0;
+		font-size: 10pt;
 		color: #828282;
 	}
 </style>

--- a/src/routes/front/+page.svelte
+++ b/src/routes/front/+page.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+	import { timeAgo, extractDomain, isNewUser } from '$lib/ranking';
+
+	let { data } = $props();
+	let votedIds = $derived(new Set(data.votedIds));
+	let localVotedIds = $state<Set<number> | null>(null);
+	let localPoints = $state<Record<number, number>>({});
+
+	function getVotedIds(): Set<number> {
+		return localVotedIds ?? votedIds;
+	}
+
+	function getPoints(story: { id: number; points: number }): number {
+		return localPoints[story.id] ?? story.points;
+	}
+
+	async function vote(storyId: number) {
+		if (!data.user) {
+			window.location.href = '/login';
+			return;
+		}
+		const res = await fetch('/api/vote', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
+		});
+		if (res.ok) {
+			const result: { voted: boolean; points: number } = await res.json();
+			localPoints = { ...localPoints, [storyId]: result.points };
+			const next = new Set(getVotedIds());
+			if (result.voted) {
+				next.add(storyId);
+			} else {
+				next.delete(storyId);
+			}
+			localVotedIds = next;
+		}
+	}
+
+	function formatDay(day: string): string {
+		const d = new Date(day + 'T00:00:00Z');
+		return d.toLocaleDateString('en-US', {
+			year: 'numeric',
+			month: 'long',
+			day: 'numeric',
+			timeZone: 'UTC'
+		});
+	}
+
+	function prevDay(day: string): string {
+		const d = new Date(day + 'T00:00:00Z');
+		d.setUTCDate(d.getUTCDate() - 1);
+		return d.toISOString().slice(0, 10);
+	}
+
+	function nextDay(day: string): string {
+		const d = new Date(day + 'T00:00:00Z');
+		d.setUTCDate(d.getUTCDate() + 1);
+		return d.toISOString().slice(0, 10);
+	}
+</script>
+
+<div class="front-nav">
+	<span class="front-nav-label">Stories from {formatDay(data.day)}</span>
+	<span class="front-nav-links">
+		&lt; <a href="/front?day={prevDay(data.day)}">prev</a>
+		|
+		<a href="/front?day={nextDay(data.day)}">next</a> &gt;
+	</span>
+</div>
+
+<div class="story-list">
+	{#each data.stories as story, i}
+		<div class="story-item">
+			<span class="story-rank">{(data.page - 1) * 30 + i + 1}.</span>
+			<span class="story-vote">
+				<button
+					class="upvote"
+					class:voted={getVotedIds().has(story.id)}
+					onclick={() => vote(story.id)}
+					aria-label="upvote"
+				>
+					&#9650;
+				</button>
+			</span>
+			<div class="story-content">
+				<div class="story-title-line">
+					{#if story.url}
+						<a href={story.url} class="story-title">{story.title}</a>
+						<span class="story-domain">({extractDomain(story.url)})</span>
+					{:else}
+						<a href="/item/{story.id}" class="story-title">{story.title}</a>
+					{/if}
+				</div>
+				<div class="story-meta">
+					{getPoints(story)} point{getPoints(story) !== 1 ? 's' : ''} by
+					<a href="/user/{story.username}" style={isNewUser(story.user_created_at) ? 'color: #3c963c;' : ''}>{story.username}</a>
+					<a href="/item/{story.id}">{timeAgo(story.created_at)}</a> |
+					<a href="/item/{story.id}"
+						>{story.comment_count} comment{story.comment_count !== 1 ? 's' : ''}</a
+					>
+				</div>
+			</div>
+		</div>
+	{/each}
+</div>
+
+{#if data.stories.length === 30}
+	<div class="more-link">
+		<a href="/front?day={data.day}&p={data.page + 1}">More</a>
+	</div>
+{/if}
+
+<style>
+	.front-nav {
+		padding: 5pt 0;
+		font-size: 7pt;
+		color: #828282;
+		font-family: Verdana, Geneva, sans-serif;
+	}
+
+	.front-nav-label {
+		margin-right: 5pt;
+	}
+
+	.front-nav-links a {
+		color: #828282;
+	}
+</style>


### PR DESCRIPTION
## 関連 Issue
closes #36

## 変更内容
- `/front` ページを新規作成（日付別フロントページ、`?day=YYYY-MM-DD` でデフォルト昨日）
- `getFrontPageStories()` をdb.tsに追加（日付範囲フィルタ + HNランクスコアソート）
- ヘッダーナビに `past` リンクを追加（`new | past | comments | ask | show | submit`）
- docs/architecture.md, docs/spec.md にルート・関数を追記