### PR TITLE
feat: RSSフィードを追加（/rss）

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,6 +25,7 @@ hacker-noroshi/
 │   │   ├── newcomments/      # 全ストーリーの最新コメント一覧
 │   │   ├── best/             # 高スコアのストーリー一覧
 │   │   ├── lists/            # ブラウズリンク集
+│   │   ├── rss/              # RSS 2.0 フィード
 │   │   ├── item/[id]/        # 投稿詳細 or コメントパーマリンク + コメント + 編集
 │   │   ├── user/[id]/        # プロフィール + 編集
 │   │   │   ├── submissions/  # ユーザーの投稿一覧
@@ -137,6 +138,7 @@ hacker-noroshi/
 | `/guidelines` | ガイドライン |
 | `/faq` | FAQ |
 | `/showhn` | Show HN ルール |
+| `/rss` | RSS 2.0 フィード（トップページのストーリー30件） |
 | `/api/vote` | 投票 API エンドポイント |
 
 ## DB アクセス関数 (src/lib/server/db.ts)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -92,6 +92,7 @@ score = (points - 1) / (hours_since_post + 2) ^ 1.8
 - [x] ヘッダーナビに comments リンク追加
 - [x] /front ページ（日付別フロントページ）+ ヘッダーナビに past リンク追加
 - [x] フッター構成を本家HNに合わせる + /lists ページ追加
+- [x] RSS フィード（/rss）追加
 
 ## v2 以降
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,6 +6,7 @@
 
 <svelte:head>
 	<title>ハッカーのろし</title>
+	<link rel="alternate" type="application/rss+xml" title="ハッカーのろし" href="/rss" />
 </svelte:head>
 
 <div class="hn-page">

--- a/src/routes/rss/+server.ts
+++ b/src/routes/rss/+server.ts
@@ -1,0 +1,49 @@
+import type { RequestHandler } from './$types';
+import { getDB, getStories } from '$lib/server/db';
+
+function escapeXml(str: string): string {
+	return str
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&apos;');
+}
+
+export const GET: RequestHandler = async ({ platform }) => {
+	const db = getDB(platform);
+	const stories = await getStories(db, { orderBy: 'rank', limit: 30 });
+
+	const items = stories
+		.map((story) => {
+			const link = story.url || `https://hn.llll-ll.com/item/${story.id}`;
+			const description = `${story.points} points by ${story.username} | ${story.comment_count} comments`;
+			const pubDate = new Date(story.created_at).toUTCString();
+
+			return `    <item>
+      <title>${escapeXml(story.title)}</title>
+      <link>${escapeXml(link)}</link>
+      <description>${escapeXml(description)}</description>
+      <pubDate>${pubDate}</pubDate>
+      <guid isPermaLink="false">https://hn.llll-ll.com/item/${story.id}</guid>
+    </item>`;
+		})
+		.join('\n');
+
+	const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>ハッカーのろし</title>
+    <link>https://hn.llll-ll.com</link>
+    <description>日本の技術者向けリンク集約サイト</description>
+    <language>ja</language>
+${items}
+  </channel>
+</rss>`;
+
+	return new Response(xml, {
+		headers: {
+			'Content-Type': 'application/rss+xml; charset=utf-8'
+		}
+	});
+};

--- a/src/routes/rss/+server.ts
+++ b/src/routes/rss/+server.ts
@@ -2,12 +2,13 @@ import type { RequestHandler } from './$types';
 import { getDB, getStories } from '$lib/server/db';
 
 function escapeXml(str: string): string {
+	if (!str) return '';
 	return str
 		.replace(/&/g, '&amp;')
 		.replace(/</g, '&lt;')
 		.replace(/>/g, '&gt;')
 		.replace(/"/g, '&quot;')
-		.replace(/'/g, '&apos;');
+		.replace(/'/g, '&#39;');
 }
 
 export const GET: RequestHandler = async ({ platform }) => {
@@ -18,11 +19,13 @@ export const GET: RequestHandler = async ({ platform }) => {
 		.map((story) => {
 			const link = story.url || `https://hn.llll-ll.com/item/${story.id}`;
 			const description = `${story.points} points by ${story.username} | ${story.comment_count} comments`;
-			const pubDate = new Date(story.created_at).toUTCString();
+			const date = new Date(story.created_at);
+			const pubDate = isNaN(date.getTime()) ? new Date().toUTCString() : date.toUTCString();
 
 			return `    <item>
       <title>${escapeXml(story.title)}</title>
       <link>${escapeXml(link)}</link>
+      <comments>https://hn.llll-ll.com/item/${story.id}</comments>
       <description>${escapeXml(description)}</description>
       <pubDate>${pubDate}</pubDate>
       <guid isPermaLink="false">https://hn.llll-ll.com/item/${story.id}</guid>
@@ -31,19 +34,22 @@ export const GET: RequestHandler = async ({ platform }) => {
 		.join('\n');
 
 	const xml = `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>ハッカーのろし</title>
     <link>https://hn.llll-ll.com</link>
     <description>日本の技術者向けリンク集約サイト</description>
     <language>ja</language>
+    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+    <atom:link href="https://hn.llll-ll.com/rss" rel="self" type="application/rss+xml" />
 ${items}
   </channel>
 </rss>`;
 
 	return new Response(xml, {
 		headers: {
-			'Content-Type': 'application/rss+xml; charset=utf-8'
+			'Content-Type': 'application/rss+xml; charset=utf-8',
+			'Cache-Control': 'public, max-age=120, s-maxage=120'
 		}
 	});
 };


### PR DESCRIPTION
## 関連 Issue
closes #27

## 変更内容
- `/rss` エンドポイントを新規作成（RSS 2.0、トップページ30件、Content-Type: application/rss+xml）
- `<link rel="alternate">` をHTMLヘッドに追加
- docs/architecture.md, docs/spec.md 更新