### PR TITLE
fix: ログインページのレイアウトを本家HNに完全合わせ

### DIFF
--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -31,9 +31,7 @@
 		<button type="submit">login</button>
 	</form>
 
-	<br />
-	<hr style="border: 0; border-top: 1pt solid #e0e0e0;" />
-	<br />
+	<br /><br />
 
 	<b>Create Account</b>
 	{#if form?.signupError}


### PR DESCRIPTION
## 関連 Issue
closes #37

## 変更内容
- ログインフォームとCreate Accountフォーム間のセパレーター（`<hr>`）を削除（本家HNにはない）
- ラベル・ボタンテキストは既に本家と一致済み
- /signup → /login リダイレクトは既に実装済み