### PR TITLE
feat: /activeページを追加（アクティブな議論一覧）

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,6 +24,7 @@ hacker-noroshi/
 │   │   ├── show/             # Show HN
 │   │   ├── newcomments/      # 全ストーリーの最新コメント一覧
 │   │   ├── best/             # 高スコアのストーリー一覧
+│   │   ├── active/           # アクティブな議論一覧
 │   │   ├── lists/            # ブラウズリンク集
 │   │   ├── rss/              # RSS 2.0 フィード
 │   │   ├── item/[id]/        # 投稿詳細 or コメントパーマリンク + コメント + 編集
@@ -126,7 +127,8 @@ hacker-noroshi/
 | `/show` | Show HN（type='show' のみ） |
 | `/newcomments` | 全ストーリーの最新コメント一覧 |
 | `/best` | 高スコアのストーリー一覧 |
-| `/lists` | ブラウズリンク集（front, newcomments, best, show, ask） |
+| `/active` | アクティブな議論一覧（最新コメント時刻順） |
+| `/lists` | ブラウズリンク集（front, newcomments, best, active, show, ask） |
 | `/item/[id]` | 投稿詳細 or コメントパーマリンク + コメントスレッド + 編集 |
 | `/user/[id]` | ユーザープロフィール + 編集 |
 | `/user/[id]/submissions` | ユーザーの投稿一覧 |
@@ -156,6 +158,7 @@ hacker-noroshi/
 | `getUserById()` | ユーザー取得（ID） |
 | `getStoriesByUserId()` | ユーザーの投稿一覧 |
 | `getCommentsByUserId()` | ユーザーのコメント一覧（story_title 付き） |
+| `getActiveStories()` | アクティブな議論（最新コメント時刻順にストーリーをソート） |
 | `getRecentComments()` | 全ストーリーの最新コメント一覧（/newcomments 用） |
 | `hasVoted()` | 投票済みチェック |
 | `getVotedStoryIds()` | 投票済みストーリーID一括取得 |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -93,6 +93,7 @@ score = (points - 1) / (hours_since_post + 2) ^ 1.8
 - [x] /front ページ（日付別フロントページ）+ ヘッダーナビに past リンク追加
 - [x] フッター構成を本家HNに合わせる + /lists ページ追加
 - [x] RSS フィード（/rss）追加
+- [x] /active ページ追加（アクティブな議論一覧）
 
 ## v2 以降
 

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -311,6 +311,25 @@ export async function getVotedCommentIds(
 	return new Set(result.results.map((r) => r.item_id));
 }
 
+export async function getActiveStories(
+	db: D1Database,
+	page: number = 1,
+	limit: number = 30
+): Promise<StoryRow[]> {
+	const offset = (page - 1) * limit;
+	const sql = `
+		SELECT s.*, u.username, u.created_at as user_created_at
+		FROM stories s
+		JOIN users u ON s.user_id = u.id
+		JOIN comments c ON c.story_id = s.id
+		GROUP BY s.id
+		ORDER BY MAX(c.created_at) DESC
+		LIMIT ? OFFSET ?
+	`;
+	const result = await db.prepare(sql).bind(limit, offset).all<StoryRow>();
+	return result.results;
+}
+
 export async function getRecentComments(
 	db: D1Database,
 	page: number = 1,

--- a/src/routes/active/+page.server.ts
+++ b/src/routes/active/+page.server.ts
@@ -1,0 +1,23 @@
+import type { PageServerLoad } from './$types';
+import { getDB, getActiveStories, getVotedStoryIds } from '$lib/server/db';
+
+export const load: PageServerLoad = async ({ url, platform, locals }) => {
+	const db = getDB(platform);
+	const page = parseInt(url.searchParams.get('p') || '1', 10);
+	const stories = await getActiveStories(db, page, 30);
+
+	let votedIds: Set<number> = new Set();
+	if (locals.user) {
+		votedIds = await getVotedStoryIds(
+			db,
+			locals.user.id,
+			stories.map((s) => s.id)
+		);
+	}
+
+	return {
+		stories,
+		page,
+		votedIds: Array.from(votedIds)
+	};
+};

--- a/src/routes/active/+page.svelte
+++ b/src/routes/active/+page.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+	import { timeAgo, extractDomain, isNewUser } from '$lib/ranking';
+
+	let { data } = $props();
+	let votedIds = $derived(new Set(data.votedIds));
+	let localVotedIds = $state<Set<number> | null>(null);
+	let localPoints = $state<Record<number, number>>({});
+
+	function getVotedIds(): Set<number> {
+		return localVotedIds ?? votedIds;
+	}
+
+	function getPoints(story: { id: number; points: number }): number {
+		return localPoints[story.id] ?? story.points;
+	}
+
+	async function vote(storyId: number) {
+		if (!data.user) {
+			window.location.href = '/login';
+			return;
+		}
+		const res = await fetch('/api/vote', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
+		});
+		if (res.ok) {
+			const result: { voted: boolean; points: number } = await res.json();
+			localPoints = { ...localPoints, [storyId]: result.points };
+			const next = new Set(getVotedIds());
+			if (result.voted) {
+				next.add(storyId);
+			} else {
+				next.delete(storyId);
+			}
+			localVotedIds = next;
+		}
+	}
+</script>
+
+<div class="story-list">
+	{#each data.stories as story, i}
+		<div class="story-item">
+			<span class="story-rank">{(data.page - 1) * 30 + i + 1}.</span>
+			<span class="story-vote">
+				<button
+					class="upvote"
+					class:voted={getVotedIds().has(story.id)}
+					onclick={() => vote(story.id)}
+					aria-label="upvote"
+				>
+					&#9650;
+				</button>
+			</span>
+			<div class="story-content">
+				<div class="story-title-line">
+					{#if story.url}
+						<a href={story.url} class="story-title">{story.title}</a>
+						<span class="story-domain">({extractDomain(story.url)})</span>
+					{:else}
+						<a href="/item/{story.id}" class="story-title">{story.title}</a>
+					{/if}
+				</div>
+				<div class="story-meta">
+					{getPoints(story)} point{getPoints(story) !== 1 ? 's' : ''} by
+					<a href="/user/{story.username}" style={isNewUser(story.user_created_at) ? 'color: #3c963c;' : ''}>{story.username}</a>
+					<a href="/item/{story.id}">{timeAgo(story.created_at)}</a> |
+					<a href="/item/{story.id}"
+						>{story.comment_count} comment{story.comment_count !== 1 ? 's' : ''}</a
+					>
+				</div>
+			</div>
+		</div>
+	{/each}
+</div>
+
+{#if data.stories.length === 30}
+	<div class="more-link">
+		<a href="/active?p={data.page + 1}">More</a>
+	</div>
+{/if}

--- a/src/routes/lists/+page.svelte
+++ b/src/routes/lists/+page.svelte
@@ -13,6 +13,10 @@
 			<td>best stories</td>
 		</tr>
 		<tr>
+			<td><a href="/active">active</a></td>
+			<td>most active current discussions</td>
+		</tr>
+		<tr>
 			<td><a href="/show">show</a></td>
 			<td>Show HN</td>
 		</tr>


### PR DESCRIPTION
## 関連 Issue
closes #39

## 変更内容
- `getActiveStories()` をdb.tsに追加（stories×comments JOIN、最新コメント時刻降順）
- `/active` ルートを新規作成（ストーリーリスト + 投票 + ページネーション）
- `/lists` に active リンクを追加
- docs/architecture.md, docs/spec.md 更新