### PR TITLE
fix: ログインページを本家HNのHTML構造に完全合わせ

### DIFF
--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -13,13 +13,14 @@
 	{#if form?.loginError}
 		<div class="form-error">{form.loginError}</div>
 	{/if}
+	<br /><br />
 
 	<form method="POST" action="?/login" use:enhance>
 		<table>
 			<tbody>
 				<tr>
 					<td>username:</td>
-					<td><input type="text" name="username" value={form?.loginUsername ?? ''} autocomplete="username" /></td>
+					<td><input type="text" name="username" value={form?.loginUsername ?? ''} autocomplete="username" autocorrect="off" spellcheck="false" autocapitalize="off" autofocus /></td>
 				</tr>
 				<tr>
 					<td>password:</td>
@@ -37,13 +38,14 @@
 	{#if form?.signupError}
 		<div class="form-error">{form.signupError}</div>
 	{/if}
+	<br /><br />
 
 	<form method="POST" action="?/signup" use:enhance>
 		<table>
 			<tbody>
 				<tr>
 					<td>username:</td>
-					<td><input type="text" name="username" value={form?.signupUsername ?? ''} autocomplete="username" /></td>
+					<td><input type="text" name="username" value={form?.signupUsername ?? ''} autocomplete="username" autocorrect="off" spellcheck="false" autocapitalize="off" /></td>
 				</tr>
 				<tr>
 					<td>password:</td>


### PR DESCRIPTION
## 背景
#37 の追加修正。本家HNのログインページソースを取得して差分を確認。

## 変更内容
- `<b>Login</b>` / `<b>Create Account</b>` の直後に `<br><br>` を追加（本家と同じ構造）
- ログインの username input に `autofocus` 属性を追加
- username input に `autocorrect="off"` `spellcheck="false"` `autocapitalize="off"` を追加（本家と同じ）