### PR TITLE
feat: APIドキュメントページを追加

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,6 +26,7 @@ hacker-noroshi/
 │   │   ├── best/             # 高スコアのストーリー一覧
 │   │   ├── active/           # アクティブな議論一覧
 │   │   ├── lists/            # ブラウズリンク集
+│   │   ├── api-docs/         # APIドキュメント
 │   │   ├── rss/              # RSS 2.0 フィード
 │   │   ├── item/[id]/        # 投稿詳細 or コメントパーマリンク + コメント + 編集
 │   │   ├── user/[id]/        # プロフィール + 編集
@@ -140,6 +141,7 @@ hacker-noroshi/
 | `/guidelines` | ガイドライン |
 | `/faq` | FAQ |
 | `/showhn` | Show HN ルール |
+| `/api-docs` | APIドキュメント（準備中） |
 | `/rss` | RSS 2.0 フィード（トップページのストーリー30件） |
 | `/api/vote` | 投票 API エンドポイント |
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -94,6 +94,7 @@ score = (points - 1) / (hours_since_post + 2) ^ 1.8
 - [x] フッター構成を本家HNに合わせる + /lists ページ追加
 - [x] RSS フィード（/rss）追加
 - [x] /active ページ追加（アクティブな議論一覧）
+- [x] APIドキュメントページ追加（/api-docs、フッターからリンク）
 
 ## v2 以降
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -44,6 +44,6 @@
 
 	<footer class="hn-footer">
 		<a href="/guidelines">Guidelines</a> | <a href="/faq">FAQ</a> | <a href="/lists">Lists</a> |
-		<span>API</span> | <a href="https://github.com/kako-jun/hacker-noroshi">GitHub</a>
+		<a href="/api-docs">API</a> | <a href="https://github.com/kako-jun/hacker-noroshi">GitHub</a>
 	</footer>
 </div>

--- a/src/routes/api-docs/+page.svelte
+++ b/src/routes/api-docs/+page.svelte
@@ -1,0 +1,32 @@
+<svelte:head>
+	<title>API | ハッカーのろし</title>
+</svelte:head>
+
+<div class="hn-form">
+	<b>Hacker Noroshi API</b>
+	<br /><br />
+
+	<p>API is under development.</p>
+
+	<p>The following endpoints are planned:</p>
+
+	<table>
+		<tbody>
+			<tr>
+				<td>Stories</td>
+				<td>Top, New, Best, Ask, Show, Active stories</td>
+			</tr>
+			<tr>
+				<td>Items</td>
+				<td>Story and comment details by ID</td>
+			</tr>
+			<tr>
+				<td>Users</td>
+				<td>User profiles by username</td>
+			</tr>
+		</tbody>
+	</table>
+
+	<br />
+	<p>Source code: <a href="https://github.com/kako-jun/hacker-noroshi">github.com/kako-jun/hacker-noroshi</a></p>
+</div>

--- a/src/routes/api-docs/+page.svelte
+++ b/src/routes/api-docs/+page.svelte
@@ -2,31 +2,18 @@
 	<title>API | ハッカーのろし</title>
 </svelte:head>
 
-<div class="hn-form">
+<div style="padding: 10px 0 10px 40px; font-size: 9pt; line-height: 14pt; color: #000000;">
 	<b>Hacker Noroshi API</b>
-	<br /><br />
 
 	<p>API is under development.</p>
 
 	<p>The following endpoints are planned:</p>
 
-	<table>
-		<tbody>
-			<tr>
-				<td>Stories</td>
-				<td>Top, New, Best, Ask, Show, Active stories</td>
-			</tr>
-			<tr>
-				<td>Items</td>
-				<td>Story and comment details by ID</td>
-			</tr>
-			<tr>
-				<td>Users</td>
-				<td>User profiles by username</td>
-			</tr>
-		</tbody>
-	</table>
+	<p>
+		<b>Stories</b> — Top, New, Best, Ask, Show, Active stories<br />
+		<b>Items</b> — Story and comment details by ID<br />
+		<b>Users</b> — User profiles by username
+	</p>
 
-	<br />
 	<p>Source code: <a href="https://github.com/kako-jun/hacker-noroshi">github.com/kako-jun/hacker-noroshi</a></p>
 </div>


### PR DESCRIPTION
## 関連 Issue
closes #4

## 変更内容
- `/api-docs` ページを新規作成（準備中の案内 + 予定エンドポイント一覧）
- フッターの `<span>API</span>` を `<a href="/api-docs">API</a>` に変更
- docs/architecture.md, docs/spec.md 更新