### PR TITLE
feat: favorites機能を追加（#19）

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -45,7 +45,15 @@ CREATE TABLE IF NOT EXISTS sessions (
   expires_at TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS favorites (
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  story_id INTEGER NOT NULL REFERENCES stories(id),
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+  PRIMARY KEY (user_id, story_id)
+);
+
 -- Indexes
+CREATE INDEX IF NOT EXISTS idx_favorites_user_id ON favorites(user_id);
 CREATE INDEX IF NOT EXISTS idx_stories_created_at ON stories(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_stories_type ON stories(type);
 CREATE INDEX IF NOT EXISTS idx_stories_user_id ON stories(user_id);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,7 +31,8 @@ hacker-noroshi/
 │   │   ├── item/[id]/        # 投稿詳細 or コメントパーマリンク + コメント + 編集
 │   │   ├── user/[id]/        # プロフィール + 編集
 │   │   │   ├── submissions/  # ユーザーの投稿一覧
-│   │   │   └── comments/     # ユーザーのコメント一覧
+│   │   │   ├── comments/     # ユーザーのコメント一覧
+│   │   │   └── favorites/    # ユーザーのお気に入り一覧
 │   │   ├── submit/           # 投稿フォーム
 │   │   ├── login/            # ログイン + サインアップ（1ページ統合）
 │   │   ├── signup/           # /login へリダイレクト
@@ -39,7 +40,9 @@ hacker-noroshi/
 │   │   ├── guidelines/       # ガイドライン
 │   │   ├── faq/              # FAQ
 │   │   ├── showhn/           # Show HN ルール
-│   │   └── api/vote/         # 投票 API
+│   │   └── api/
+│   │       ├── vote/         # 投票 API
+│   │       └── favorite/     # お気に入り API
 │   ├── lib/
 │   │   ├── server/
 │   │   │   ├── db.ts         # D1 データアクセス関数
@@ -117,6 +120,14 @@ hacker-noroshi/
 | user_id | INTEGER FK | |
 | expires_at | TEXT | ISO8601 |
 
+### favorites
+
+| カラム | 型 | 備考 |
+|---|---|---|
+| user_id | INTEGER FK | PK (複合) |
+| story_id | INTEGER FK | PK (複合) |
+| created_at | TEXT | ISO8601 |
+
 ## ルート一覧
 
 | パス | 説明 |
@@ -134,6 +145,7 @@ hacker-noroshi/
 | `/user/[id]` | ユーザープロフィール + 編集 |
 | `/user/[id]/submissions` | ユーザーの投稿一覧 |
 | `/user/[id]/comments` | ユーザーのコメント一覧 |
+| `/user/[id]/favorites` | ユーザーのお気に入り一覧 |
 | `/submit` | 投稿フォーム（要ログイン） |
 | `/login` | ログイン + サインアップ（本家HN準拠で1ページ統合） |
 | `/signup` | /login へリダイレクト（既存リンク互換） |
@@ -144,6 +156,7 @@ hacker-noroshi/
 | `/api-docs` | APIドキュメント（準備中） |
 | `/rss` | RSS 2.0 フィード（トップページのストーリー30件） |
 | `/api/vote` | 投票 API エンドポイント |
+| `/api/favorite` | お気に入り API エンドポイント |
 
 ## DB アクセス関数 (src/lib/server/db.ts)
 
@@ -165,3 +178,6 @@ hacker-noroshi/
 | `hasVoted()` | 投票済みチェック |
 | `getVotedStoryIds()` | 投票済みストーリーID一括取得 |
 | `getVotedCommentIds()` | 投票済みコメントID一括取得 |
+| `hasFavorited()` | お気に入り済みチェック |
+| `getFavoriteStoryIds()` | お気に入り済みストーリーID一括取得 |
+| `getFavoriteStoriesByUserId()` | ユーザーのお気に入りストーリー一覧 |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -95,6 +95,7 @@ score = (points - 1) / (hours_since_post + 2) ^ 1.8
 - [x] RSS フィード（/rss）追加
 - [x] /active ページ追加（アクティブな議論一覧）
 - [x] APIドキュメントページ追加（/api-docs、フッターからリンク）
+- [x] favorites 機能（favorite/un-fav トグル + /user/[id]/favorites 一覧）
 
 ## v2 以降
 
@@ -104,4 +105,4 @@ score = (points - 1) / (hours_since_post + 2) ^ 1.8
 - API 公開
 - 招待制 / カルマ制限
 - ダークモード
-- favorites 機能（DB テーブル追加 + お気に入りボタン + 一覧ページ）
+- ~~favorites 機能~~ → v1 で実装済み

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -330,6 +330,56 @@ export async function getActiveStories(
 	return result.results;
 }
 
+export async function hasFavorited(
+	db: D1Database,
+	userId: number,
+	storyId: number
+): Promise<boolean> {
+	const result = await db
+		.prepare('SELECT 1 FROM favorites WHERE user_id = ? AND story_id = ?')
+		.bind(userId, storyId)
+		.first();
+	return result !== null;
+}
+
+export async function getFavoriteStoryIds(
+	db: D1Database,
+	userId: number,
+	storyIds: number[]
+): Promise<Set<number>> {
+	if (storyIds.length === 0) return new Set();
+	const placeholders = storyIds.map(() => '?').join(',');
+	const result = await db
+		.prepare(
+			`SELECT story_id FROM favorites WHERE user_id = ? AND story_id IN (${placeholders})`
+		)
+		.bind(userId, ...storyIds)
+		.all<{ story_id: number }>();
+	return new Set(result.results.map((r) => r.story_id));
+}
+
+export async function getFavoriteStoriesByUserId(
+	db: D1Database,
+	userId: number,
+	page: number = 1,
+	limit: number = 30
+): Promise<StoryRow[]> {
+	const offset = (page - 1) * limit;
+	const result = await db
+		.prepare(
+			`SELECT s.*, u.username, u.created_at as user_created_at
+			FROM favorites f
+			JOIN stories s ON f.story_id = s.id
+			JOIN users u ON s.user_id = u.id
+			WHERE f.user_id = ?
+			ORDER BY f.created_at DESC
+			LIMIT ? OFFSET ?`
+		)
+		.bind(userId, limit, offset)
+		.all<StoryRow>();
+	return result.results;
+}
+
 export async function getRecentComments(
 	db: D1Database,
 	page: number = 1,

--- a/src/routes/api/favorite/+server.ts
+++ b/src/routes/api/favorite/+server.ts
@@ -1,0 +1,33 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { getDB, hasFavorited } from '$lib/server/db';
+
+export const POST: RequestHandler = async ({ request, platform, locals }) => {
+	if (!locals.user) {
+		return json({ error: 'Not authenticated' }, { status: 401 });
+	}
+
+	const db = getDB(platform);
+	const body = (await request.json()) as { storyId: number };
+	const { storyId } = body;
+
+	if (!storyId) {
+		return json({ error: 'Invalid request' }, { status: 400 });
+	}
+
+	const alreadyFavorited = await hasFavorited(db, locals.user.id, storyId);
+
+	if (alreadyFavorited) {
+		await db
+			.prepare('DELETE FROM favorites WHERE user_id = ? AND story_id = ?')
+			.bind(locals.user.id, storyId)
+			.run();
+		return json({ favorited: false });
+	} else {
+		await db
+			.prepare('INSERT INTO favorites (user_id, story_id) VALUES (?, ?)')
+			.bind(locals.user.id, storyId)
+			.run();
+		return json({ favorited: true });
+	}
+};

--- a/src/routes/api/favorite/+server.ts
+++ b/src/routes/api/favorite/+server.ts
@@ -1,6 +1,6 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { getDB, hasFavorited } from '$lib/server/db';
+import { getDB, hasFavorited, getStoryById } from '$lib/server/db';
 
 export const POST: RequestHandler = async ({ request, platform, locals }) => {
 	if (!locals.user) {
@@ -11,8 +11,13 @@ export const POST: RequestHandler = async ({ request, platform, locals }) => {
 	const body = (await request.json()) as { storyId: number };
 	const { storyId } = body;
 
-	if (!storyId) {
+	if (!storyId || typeof storyId !== 'number') {
 		return json({ error: 'Invalid request' }, { status: 400 });
+	}
+
+	const story = await getStoryById(db, storyId);
+	if (!story) {
+		return json({ error: 'Story not found' }, { status: 404 });
 	}
 
 	const alreadyFavorited = await hasFavorited(db, locals.user.id, storyId);

--- a/src/routes/item/[id]/+page.server.ts
+++ b/src/routes/item/[id]/+page.server.ts
@@ -20,13 +20,11 @@ export const load: PageServerLoad = async ({ params, platform, locals }) => {
 		let votedCommentIds: Set<number> = new Set();
 
 		if (locals.user) {
-			storyVoted = await hasVoted(db, locals.user.id, id, 'story');
-			storyFavorited = await hasFavorited(db, locals.user.id, id);
-			votedCommentIds = await getVotedCommentIds(
-				db,
-				locals.user.id,
-				comments.map((c) => c.id)
-			);
+			[storyVoted, storyFavorited, votedCommentIds] = await Promise.all([
+				hasVoted(db, locals.user.id, id, 'story'),
+				hasFavorited(db, locals.user.id, id),
+				getVotedCommentIds(db, locals.user.id, comments.map((c) => c.id))
+			]);
 		}
 
 		return {

--- a/src/routes/item/[id]/+page.server.ts
+++ b/src/routes/item/[id]/+page.server.ts
@@ -1,5 +1,5 @@
 import type { PageServerLoad, Actions } from './$types';
-import { getDB, getStoryById, getCommentsByStoryId, getCommentById, getChildComments, getVotedCommentIds, hasVoted } from '$lib/server/db';
+import { getDB, getStoryById, getCommentsByStoryId, getCommentById, getChildComments, getVotedCommentIds, hasVoted, hasFavorited } from '$lib/server/db';
 import { error, fail, redirect } from '@sveltejs/kit';
 
 export const load: PageServerLoad = async ({ params, platform, locals }) => {
@@ -16,10 +16,12 @@ export const load: PageServerLoad = async ({ params, platform, locals }) => {
 		const comments = await getCommentsByStoryId(db, id);
 
 		let storyVoted = false;
+		let storyFavorited = false;
 		let votedCommentIds: Set<number> = new Set();
 
 		if (locals.user) {
 			storyVoted = await hasVoted(db, locals.user.id, id, 'story');
+			storyFavorited = await hasFavorited(db, locals.user.id, id);
 			votedCommentIds = await getVotedCommentIds(
 				db,
 				locals.user.id,
@@ -32,6 +34,7 @@ export const load: PageServerLoad = async ({ params, platform, locals }) => {
 			story,
 			comments,
 			storyVoted,
+			storyFavorited,
 			votedCommentIds: Array.from(votedCommentIds)
 		};
 	}

--- a/src/routes/item/[id]/+page.svelte
+++ b/src/routes/item/[id]/+page.svelte
@@ -14,6 +14,7 @@
 	let editingCommentId = $state<number | null>(null);
 	let localTargetCommentVoted = $state<boolean | null>(null);
 	let localTargetCommentPoints = $state<number | null>(null);
+	let localStoryFavorited = $state<boolean | null>(null);
 
 	function canEdit(createdAt: string, userId: number): boolean {
 		if (!data.user || data.user.id !== userId) return false;
@@ -23,6 +24,7 @@
 
 	let storyVoted = $derived(localStoryVoted ?? (data.mode === 'story' ? data.storyVoted : false));
 	let storyPoints = $derived(localStoryPoints ?? (data.mode === 'story' ? data.story.points : 0));
+	let storyFavorited = $derived(localStoryFavorited ?? (data.mode === 'story' ? data.storyFavorited : false));
 	let votedCommentIdsFromServer = $derived(new Set(data.votedCommentIds));
 
 	function getVotedCommentIds(): Set<number> {
@@ -156,6 +158,23 @@
 				next.delete(commentId);
 			}
 			localVotedCommentIds = next;
+		}
+	}
+
+	async function toggleFavorite() {
+		if (!data.user) {
+			window.location.href = '/login';
+			return;
+		}
+		if (data.mode !== 'story') return;
+		const res = await fetch('/api/favorite', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ storyId: data.story.id })
+		});
+		if (res.ok) {
+			const result: { favorited: boolean } = await res.json();
+			localStoryFavorited = result.favorited;
 		}
 	}
 
@@ -365,6 +384,14 @@
 						e.preventDefault();
 						editingStory = true;
 					}}>edit</a>
+			{/if}
+			{#if data.user}
+				| <a
+					href="#favorite"
+					onclick={(e) => {
+						e.preventDefault();
+						toggleFavorite();
+					}}>{storyFavorited ? 'un-fav' : 'favorite'}</a>
 			{/if}
 		</div>
 

--- a/src/routes/user/[id]/+page.svelte
+++ b/src/routes/user/[id]/+page.svelte
@@ -50,6 +50,7 @@
 
 	<div style="margin-top: 10px; font-size: 10pt;">
 		<a href="/user/{data.profile.username}/submissions">submissions</a><br />
-		<a href="/user/{data.profile.username}/comments">comments</a>
+		<a href="/user/{data.profile.username}/comments">comments</a><br />
+		<a href="/user/{data.profile.username}/favorites">favorites</a>
 	</div>
 </div>

--- a/src/routes/user/[id]/favorites/+page.server.ts
+++ b/src/routes/user/[id]/favorites/+page.server.ts
@@ -1,0 +1,32 @@
+import type { PageServerLoad } from './$types';
+import { getDB, getUserByUsername, getFavoriteStoriesByUserId, getVotedStoryIds } from '$lib/server/db';
+import { error } from '@sveltejs/kit';
+
+export const load: PageServerLoad = async ({ params, url, platform, locals }) => {
+	const db = getDB(platform);
+	const username = params.id;
+	const page = parseInt(url.searchParams.get('p') || '1', 10);
+
+	const user = await getUserByUsername(db, username);
+	if (!user) {
+		throw error(404, 'User not found');
+	}
+
+	const favorites = await getFavoriteStoriesByUserId(db, user.id, page, 30);
+
+	let votedIds: Set<number> = new Set();
+	if (locals.user) {
+		votedIds = await getVotedStoryIds(
+			db,
+			locals.user.id,
+			favorites.map((s) => s.id)
+		);
+	}
+
+	return {
+		username: user.username,
+		favorites,
+		votedIds: Array.from(votedIds),
+		page
+	};
+};

--- a/src/routes/user/[id]/favorites/+page.svelte
+++ b/src/routes/user/[id]/favorites/+page.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import { timeAgo, extractDomain, isNewUser } from '$lib/ranking';
+
+	let { data } = $props();
+	let votedIds = $derived(new Set(data.votedIds));
+	let localVotedIds = $state<Set<number> | null>(null);
+	let localPoints = $state<Record<number, number>>({});
+
+	function getVotedIds(): Set<number> {
+		return localVotedIds ?? votedIds;
+	}
+
+	function getPoints(story: { id: number; points: number }): number {
+		return localPoints[story.id] ?? story.points;
+	}
+
+	async function vote(storyId: number) {
+		if (!data.user) {
+			window.location.href = '/login';
+			return;
+		}
+		const res = await fetch('/api/vote', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
+		});
+		if (res.ok) {
+			const result: { voted: boolean; points: number } = await res.json();
+			localPoints = { ...localPoints, [storyId]: result.points };
+			const next = new Set(getVotedIds());
+			if (result.voted) {
+				next.add(storyId);
+			} else {
+				next.delete(storyId);
+			}
+			localVotedIds = next;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>{data.username}'s favorites | ハッカーのろし</title>
+</svelte:head>
+
+<div class="story-list" style="padding-left: 40px;">
+	{#each data.favorites as story, i}
+		<div class="story-item">
+			<span class="story-rank">{(data.page - 1) * 30 + i + 1}.</span>
+			<span class="story-vote">
+				<button
+					class="upvote"
+					class:voted={getVotedIds().has(story.id)}
+					onclick={() => vote(story.id)}
+					aria-label="upvote"
+				>
+					&#9650;
+				</button>
+			</span>
+			<div class="story-content">
+				<div class="story-title-line">
+					{#if story.url}
+						<a href={story.url} class="story-title">{story.title}</a>
+						<span class="story-domain">({extractDomain(story.url)})</span>
+					{:else}
+						<a href="/item/{story.id}" class="story-title">{story.title}</a>
+					{/if}
+				</div>
+				<div class="story-meta">
+					{getPoints(story)} point{getPoints(story) !== 1 ? 's' : ''} by
+					<a href="/user/{story.username}" style={isNewUser(story.user_created_at) ? 'color: #3c963c;' : ''}>{story.username}</a>
+					<a href="/item/{story.id}">{timeAgo(story.created_at)}</a> |
+					<a href="/item/{story.id}"
+						>{story.comment_count} comment{story.comment_count !== 1 ? 's' : ''}</a
+					>
+				</div>
+			</div>
+		</div>
+	{/each}
+</div>
+
+{#if data.favorites.length === 30}
+	<div class="more-link">
+		<a href="/user/{data.username}/favorites?p={data.page + 1}">More</a>
+	</div>
+{/if}


### PR DESCRIPTION
## 関連 Issue
closes #19

## 変更内容
- `favorites` テーブル追加（user_id, story_id 複合PK）
- DB関数追加: `hasFavorited`, `getFavoriteStoryIds`, `getFavoriteStoriesByUserId`
- `/api/favorite` エンドポイント追加（POST トグル）
- ストーリー詳細ページに `favorite` / `un-fav` テキストリンク追加
- `/user/[id]/favorites` 一覧ページ追加（ページネーション付き）
- プロフィールページに favorites リンク追加
- docs/spec.md, docs/architecture.md 更新