### PR TITLE
feat: ストーリーのhide機能を追加（#18）

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -52,7 +52,15 @@ CREATE TABLE IF NOT EXISTS favorites (
   PRIMARY KEY (user_id, story_id)
 );
 
+CREATE TABLE IF NOT EXISTS hidden (
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  story_id INTEGER NOT NULL REFERENCES stories(id),
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+  PRIMARY KEY (user_id, story_id)
+);
+
 -- Indexes
+CREATE INDEX IF NOT EXISTS idx_hidden_user_id ON hidden(user_id);
 CREATE INDEX IF NOT EXISTS idx_favorites_user_id ON favorites(user_id);
 CREATE INDEX IF NOT EXISTS idx_stories_created_at ON stories(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_stories_type ON stories(type);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,7 +32,8 @@ hacker-noroshi/
 │   │   ├── user/[id]/        # プロフィール + 編集
 │   │   │   ├── submissions/  # ユーザーの投稿一覧
 │   │   │   ├── comments/     # ユーザーのコメント一覧
-│   │   │   └── favorites/    # ユーザーのお気に入り一覧
+│   │   │   ├── favorites/    # ユーザーのお気に入り一覧
+│   │   │   └── hidden/       # 非表示ストーリー一覧（本人のみ）
 │   │   ├── submit/           # 投稿フォーム
 │   │   ├── login/            # ログイン + サインアップ（1ページ統合）
 │   │   ├── signup/           # /login へリダイレクト
@@ -42,7 +43,8 @@ hacker-noroshi/
 │   │   ├── showhn/           # Show HN ルール
 │   │   └── api/
 │   │       ├── vote/         # 投票 API
-│   │       └── favorite/     # お気に入り API
+│   │       ├── favorite/     # お気に入り API
+│   │       └── hide/         # 非表示 API
 │   ├── lib/
 │   │   ├── server/
 │   │   │   ├── db.ts         # D1 データアクセス関数
@@ -128,6 +130,14 @@ hacker-noroshi/
 | story_id | INTEGER FK | PK (複合) |
 | created_at | TEXT | ISO8601 |
 
+### hidden
+
+| カラム | 型 | 備考 |
+|---|---|---|
+| user_id | INTEGER FK | PK (複合) |
+| story_id | INTEGER FK | PK (複合) |
+| created_at | TEXT | ISO8601 |
+
 ## ルート一覧
 
 | パス | 説明 |
@@ -146,6 +156,7 @@ hacker-noroshi/
 | `/user/[id]/submissions` | ユーザーの投稿一覧 |
 | `/user/[id]/comments` | ユーザーのコメント一覧 |
 | `/user/[id]/favorites` | ユーザーのお気に入り一覧 |
+| `/user/[id]/hidden` | 非表示ストーリー一覧（本人のみ） |
 | `/submit` | 投稿フォーム（要ログイン） |
 | `/login` | ログイン + サインアップ（本家HN準拠で1ページ統合） |
 | `/signup` | /login へリダイレクト（既存リンク互換） |
@@ -157,6 +168,7 @@ hacker-noroshi/
 | `/rss` | RSS 2.0 フィード（トップページのストーリー30件） |
 | `/api/vote` | 投票 API エンドポイント |
 | `/api/favorite` | お気に入り API エンドポイント |
+| `/api/hide` | 非表示 API エンドポイント |
 
 ## DB アクセス関数 (src/lib/server/db.ts)
 
@@ -181,3 +193,6 @@ hacker-noroshi/
 | `hasFavorited()` | お気に入り済みチェック |
 | `getFavoriteStoryIds()` | お気に入り済みストーリーID一括取得 |
 | `getFavoriteStoriesByUserId()` | ユーザーのお気に入りストーリー一覧 |
+| `hasHidden()` | 非表示済みチェック |
+| `getHiddenStoryIds()` | ユーザーの全非表示ストーリーID取得 |
+| `getHiddenStoriesByUserId()` | ユーザーの非表示ストーリー一覧 |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -96,6 +96,7 @@ score = (points - 1) / (hours_since_post + 2) ^ 1.8
 - [x] /active ページ追加（アクティブな議論一覧）
 - [x] APIドキュメントページ追加（/api-docs、フッターからリンク）
 - [x] favorites 機能（favorite/un-fav トグル + /user/[id]/favorites 一覧）
+- [x] hide 機能（ストーリー非表示 + /user/[id]/hidden 一覧 + 一覧からの除外）
 
 ## v2 以降
 

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -380,6 +380,51 @@ export async function getFavoriteStoriesByUserId(
 	return result.results;
 }
 
+export async function hasHidden(
+	db: D1Database,
+	userId: number,
+	storyId: number
+): Promise<boolean> {
+	const result = await db
+		.prepare('SELECT 1 FROM hidden WHERE user_id = ? AND story_id = ?')
+		.bind(userId, storyId)
+		.first();
+	return result !== null;
+}
+
+export async function getHiddenStoryIds(
+	db: D1Database,
+	userId: number
+): Promise<Set<number>> {
+	const result = await db
+		.prepare('SELECT story_id FROM hidden WHERE user_id = ?')
+		.bind(userId)
+		.all<{ story_id: number }>();
+	return new Set(result.results.map((r) => r.story_id));
+}
+
+export async function getHiddenStoriesByUserId(
+	db: D1Database,
+	userId: number,
+	page: number = 1,
+	limit: number = 30
+): Promise<StoryRow[]> {
+	const offset = (page - 1) * limit;
+	const result = await db
+		.prepare(
+			`SELECT s.*, u.username, u.created_at as user_created_at
+			FROM hidden h
+			JOIN stories s ON h.story_id = s.id
+			JOIN users u ON s.user_id = u.id
+			WHERE h.user_id = ?
+			ORDER BY h.created_at DESC
+			LIMIT ? OFFSET ?`
+		)
+		.bind(userId, limit, offset)
+		.all<StoryRow>();
+	return result.results;
+}
+
 export async function getRecentComments(
 	db: D1Database,
 	page: number = 1,

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -4,7 +4,7 @@ import { getDB, getStories, getVotedStoryIds, getHiddenStoryIds } from '$lib/ser
 export const load: PageServerLoad = async ({ url, platform, locals }) => {
 	const db = getDB(platform);
 	const page = parseInt(url.searchParams.get('p') || '1', 10);
-	let stories = await getStories(db, { orderBy: 'rank', page, limit: 30 });
+	let stories = await getStories(db, { orderBy: 'rank', page, limit: 60 });
 
 	let votedIds: Set<number> = new Set();
 	let hiddenIds: Set<number> = new Set();
@@ -13,13 +13,12 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 			getVotedStoryIds(db, locals.user.id, stories.map((s) => s.id)),
 			getHiddenStoryIds(db, locals.user.id)
 		]);
-		stories = stories.filter((s) => !hiddenIds.has(s.id));
+		stories = stories.filter((s) => !hiddenIds.has(s.id)).slice(0, 30);
 	}
 
 	return {
 		stories,
 		page,
-		votedIds: Array.from(votedIds),
-		hiddenIds: Array.from(hiddenIds)
+		votedIds: Array.from(votedIds)
 	};
 };

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,23 +1,25 @@
 import type { PageServerLoad } from './$types';
-import { getDB, getStories, getVotedStoryIds } from '$lib/server/db';
+import { getDB, getStories, getVotedStoryIds, getHiddenStoryIds } from '$lib/server/db';
 
 export const load: PageServerLoad = async ({ url, platform, locals }) => {
 	const db = getDB(platform);
 	const page = parseInt(url.searchParams.get('p') || '1', 10);
-	const stories = await getStories(db, { orderBy: 'rank', page, limit: 30 });
+	let stories = await getStories(db, { orderBy: 'rank', page, limit: 30 });
 
 	let votedIds: Set<number> = new Set();
+	let hiddenIds: Set<number> = new Set();
 	if (locals.user) {
-		votedIds = await getVotedStoryIds(
-			db,
-			locals.user.id,
-			stories.map((s) => s.id)
-		);
+		[votedIds, hiddenIds] = await Promise.all([
+			getVotedStoryIds(db, locals.user.id, stories.map((s) => s.id)),
+			getHiddenStoryIds(db, locals.user.id)
+		]);
+		stories = stories.filter((s) => !hiddenIds.has(s.id));
 	}
 
 	return {
 		stories,
 		page,
-		votedIds: Array.from(votedIds)
+		votedIds: Array.from(votedIds),
+		hiddenIds: Array.from(hiddenIds)
 	};
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,7 +3,6 @@
 
 	let { data } = $props();
 	let votedIds = $derived(new Set(data.votedIds));
-	let hiddenIds = $derived(new Set(data.hiddenIds ?? []));
 	let localVotedIds = $state<Set<number> | null>(null);
 	let localPoints = $state<Record<number, number>>({});
 	let localHiddenIds = $state<Set<number>>(new Set());
@@ -17,7 +16,7 @@
 	}
 
 	function isHidden(id: number): boolean {
-		return localHiddenIds.has(id) || hiddenIds.has(id);
+		return localHiddenIds.has(id);
 	}
 
 	async function hide(storyId: number) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,8 +3,10 @@
 
 	let { data } = $props();
 	let votedIds = $derived(new Set(data.votedIds));
+	let hiddenIds = $derived(new Set(data.hiddenIds ?? []));
 	let localVotedIds = $state<Set<number> | null>(null);
 	let localPoints = $state<Record<number, number>>({});
+	let localHiddenIds = $state<Set<number>>(new Set());
 
 	function getVotedIds(): Set<number> {
 		return localVotedIds ?? votedIds;
@@ -12,6 +14,26 @@
 
 	function getPoints(story: { id: number; points: number }): number {
 		return localPoints[story.id] ?? story.points;
+	}
+
+	function isHidden(id: number): boolean {
+		return localHiddenIds.has(id) || hiddenIds.has(id);
+	}
+
+	async function hide(storyId: number) {
+		const res = await fetch('/api/hide', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ storyId })
+		});
+		if (res.ok) {
+			const result: { hidden: boolean } = await res.json();
+			if (result.hidden) {
+				const next = new Set(localHiddenIds);
+				next.add(storyId);
+				localHiddenIds = next;
+			}
+		}
 	}
 
 	async function vote(storyId: number) {
@@ -40,6 +62,7 @@
 
 <div class="story-list">
 	{#each data.stories as story, i}
+		{#if !isHidden(story.id)}
 		<div class="story-item">
 			<span class="story-rank">{(data.page - 1) * 30 + i + 1}.</span>
 			<span class="story-vote">
@@ -68,9 +91,13 @@
 					<a href="/item/{story.id}"
 						>{story.comment_count} comment{story.comment_count !== 1 ? 's' : ''}</a
 					>
+					{#if data.user}
+						| <a href="#hide" onclick={(e) => { e.preventDefault(); hide(story.id); }}>hide</a>
+					{/if}
 				</div>
 			</div>
 		</div>
+		{/if}
 	{/each}
 </div>
 

--- a/src/routes/active/+page.server.ts
+++ b/src/routes/active/+page.server.ts
@@ -1,23 +1,25 @@
 import type { PageServerLoad } from './$types';
-import { getDB, getActiveStories, getVotedStoryIds } from '$lib/server/db';
+import { getDB, getActiveStories, getVotedStoryIds, getHiddenStoryIds } from '$lib/server/db';
 
 export const load: PageServerLoad = async ({ url, platform, locals }) => {
 	const db = getDB(platform);
 	const page = parseInt(url.searchParams.get('p') || '1', 10);
-	const stories = await getActiveStories(db, page, 30);
+	let stories = await getActiveStories(db, page, 30);
 
 	let votedIds: Set<number> = new Set();
+	let hiddenIds: Set<number> = new Set();
 	if (locals.user) {
-		votedIds = await getVotedStoryIds(
-			db,
-			locals.user.id,
-			stories.map((s) => s.id)
-		);
+		[votedIds, hiddenIds] = await Promise.all([
+			getVotedStoryIds(db, locals.user.id, stories.map((s) => s.id)),
+			getHiddenStoryIds(db, locals.user.id)
+		]);
+		stories = stories.filter((s) => !hiddenIds.has(s.id));
 	}
 
 	return {
 		stories,
 		page,
-		votedIds: Array.from(votedIds)
+		votedIds: Array.from(votedIds),
+		hiddenIds: Array.from(hiddenIds)
 	};
 };

--- a/src/routes/active/+page.server.ts
+++ b/src/routes/active/+page.server.ts
@@ -4,7 +4,7 @@ import { getDB, getActiveStories, getVotedStoryIds, getHiddenStoryIds } from '$l
 export const load: PageServerLoad = async ({ url, platform, locals }) => {
 	const db = getDB(platform);
 	const page = parseInt(url.searchParams.get('p') || '1', 10);
-	let stories = await getActiveStories(db, page, 30);
+	let stories = await getActiveStories(db, page, 60);
 
 	let votedIds: Set<number> = new Set();
 	let hiddenIds: Set<number> = new Set();
@@ -13,13 +13,12 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 			getVotedStoryIds(db, locals.user.id, stories.map((s) => s.id)),
 			getHiddenStoryIds(db, locals.user.id)
 		]);
-		stories = stories.filter((s) => !hiddenIds.has(s.id));
+		stories = stories.filter((s) => !hiddenIds.has(s.id)).slice(0, 30);
 	}
 
 	return {
 		stories,
 		page,
-		votedIds: Array.from(votedIds),
-		hiddenIds: Array.from(hiddenIds)
+		votedIds: Array.from(votedIds)
 	};
 };

--- a/src/routes/active/+page.svelte
+++ b/src/routes/active/+page.svelte
@@ -3,7 +3,6 @@
 
 	let { data } = $props();
 	let votedIds = $derived(new Set(data.votedIds));
-	let hiddenIds = $derived(new Set(data.hiddenIds ?? []));
 	let localVotedIds = $state<Set<number> | null>(null);
 	let localPoints = $state<Record<number, number>>({});
 	let localHiddenIds = $state<Set<number>>(new Set());
@@ -17,7 +16,7 @@
 	}
 
 	function isHidden(id: number): boolean {
-		return localHiddenIds.has(id) || hiddenIds.has(id);
+		return localHiddenIds.has(id);
 	}
 
 	async function hide(storyId: number) {

--- a/src/routes/active/+page.svelte
+++ b/src/routes/active/+page.svelte
@@ -3,8 +3,10 @@
 
 	let { data } = $props();
 	let votedIds = $derived(new Set(data.votedIds));
+	let hiddenIds = $derived(new Set(data.hiddenIds ?? []));
 	let localVotedIds = $state<Set<number> | null>(null);
 	let localPoints = $state<Record<number, number>>({});
+	let localHiddenIds = $state<Set<number>>(new Set());
 
 	function getVotedIds(): Set<number> {
 		return localVotedIds ?? votedIds;
@@ -12,6 +14,26 @@
 
 	function getPoints(story: { id: number; points: number }): number {
 		return localPoints[story.id] ?? story.points;
+	}
+
+	function isHidden(id: number): boolean {
+		return localHiddenIds.has(id) || hiddenIds.has(id);
+	}
+
+	async function hide(storyId: number) {
+		const res = await fetch('/api/hide', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ storyId })
+		});
+		if (res.ok) {
+			const result: { hidden: boolean } = await res.json();
+			if (result.hidden) {
+				const next = new Set(localHiddenIds);
+				next.add(storyId);
+				localHiddenIds = next;
+			}
+		}
 	}
 
 	async function vote(storyId: number) {
@@ -40,6 +62,7 @@
 
 <div class="story-list">
 	{#each data.stories as story, i}
+		{#if !isHidden(story.id)}
 		<div class="story-item">
 			<span class="story-rank">{(data.page - 1) * 30 + i + 1}.</span>
 			<span class="story-vote">
@@ -68,9 +91,13 @@
 					<a href="/item/{story.id}"
 						>{story.comment_count} comment{story.comment_count !== 1 ? 's' : ''}</a
 					>
+					{#if data.user}
+						| <a href="#hide" onclick={(e) => { e.preventDefault(); hide(story.id); }}>hide</a>
+					{/if}
 				</div>
 			</div>
 		</div>
+		{/if}
 	{/each}
 </div>
 

--- a/src/routes/api/hide/+server.ts
+++ b/src/routes/api/hide/+server.ts
@@ -1,0 +1,38 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { getDB, hasHidden, getStoryById } from '$lib/server/db';
+
+export const POST: RequestHandler = async ({ request, platform, locals }) => {
+	if (!locals.user) {
+		return json({ error: 'Not authenticated' }, { status: 401 });
+	}
+
+	const db = getDB(platform);
+	const body = (await request.json()) as { storyId: number };
+	const { storyId } = body;
+
+	if (!storyId || typeof storyId !== 'number') {
+		return json({ error: 'Invalid request' }, { status: 400 });
+	}
+
+	const story = await getStoryById(db, storyId);
+	if (!story) {
+		return json({ error: 'Story not found' }, { status: 404 });
+	}
+
+	const alreadyHidden = await hasHidden(db, locals.user.id, storyId);
+
+	if (alreadyHidden) {
+		await db
+			.prepare('DELETE FROM hidden WHERE user_id = ? AND story_id = ?')
+			.bind(locals.user.id, storyId)
+			.run();
+		return json({ hidden: false });
+	} else {
+		await db
+			.prepare('INSERT INTO hidden (user_id, story_id) VALUES (?, ?)')
+			.bind(locals.user.id, storyId)
+			.run();
+		return json({ hidden: true });
+	}
+};

--- a/src/routes/ask/+page.server.ts
+++ b/src/routes/ask/+page.server.ts
@@ -1,23 +1,25 @@
 import type { PageServerLoad } from './$types';
-import { getDB, getStories, getVotedStoryIds } from '$lib/server/db';
+import { getDB, getStories, getVotedStoryIds, getHiddenStoryIds } from '$lib/server/db';
 
 export const load: PageServerLoad = async ({ url, platform, locals }) => {
 	const db = getDB(platform);
 	const page = parseInt(url.searchParams.get('p') || '1', 10);
-	const stories = await getStories(db, { type: 'ask', orderBy: 'rank', page, limit: 30 });
+	let stories = await getStories(db, { type: 'ask', orderBy: 'rank', page, limit: 30 });
 
 	let votedIds: Set<number> = new Set();
+	let hiddenIds: Set<number> = new Set();
 	if (locals.user) {
-		votedIds = await getVotedStoryIds(
-			db,
-			locals.user.id,
-			stories.map((s) => s.id)
-		);
+		[votedIds, hiddenIds] = await Promise.all([
+			getVotedStoryIds(db, locals.user.id, stories.map((s) => s.id)),
+			getHiddenStoryIds(db, locals.user.id)
+		]);
+		stories = stories.filter((s) => !hiddenIds.has(s.id));
 	}
 
 	return {
 		stories,
 		page,
-		votedIds: Array.from(votedIds)
+		votedIds: Array.from(votedIds),
+		hiddenIds: Array.from(hiddenIds)
 	};
 };

--- a/src/routes/ask/+page.server.ts
+++ b/src/routes/ask/+page.server.ts
@@ -4,7 +4,7 @@ import { getDB, getStories, getVotedStoryIds, getHiddenStoryIds } from '$lib/ser
 export const load: PageServerLoad = async ({ url, platform, locals }) => {
 	const db = getDB(platform);
 	const page = parseInt(url.searchParams.get('p') || '1', 10);
-	let stories = await getStories(db, { type: 'ask', orderBy: 'rank', page, limit: 30 });
+	let stories = await getStories(db, { type: 'ask', orderBy: 'rank', page, limit: 60 });
 
 	let votedIds: Set<number> = new Set();
 	let hiddenIds: Set<number> = new Set();
@@ -13,13 +13,12 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 			getVotedStoryIds(db, locals.user.id, stories.map((s) => s.id)),
 			getHiddenStoryIds(db, locals.user.id)
 		]);
-		stories = stories.filter((s) => !hiddenIds.has(s.id));
+		stories = stories.filter((s) => !hiddenIds.has(s.id)).slice(0, 30);
 	}
 
 	return {
 		stories,
 		page,
-		votedIds: Array.from(votedIds),
-		hiddenIds: Array.from(hiddenIds)
+		votedIds: Array.from(votedIds)
 	};
 };

--- a/src/routes/ask/+page.svelte
+++ b/src/routes/ask/+page.svelte
@@ -3,7 +3,6 @@
 
 	let { data } = $props();
 	let votedIds = $derived(new Set(data.votedIds));
-	let hiddenIds = $derived(new Set(data.hiddenIds ?? []));
 	let localVotedIds = $state<Set<number> | null>(null);
 	let localPoints = $state<Record<number, number>>({});
 	let localHiddenIds = $state<Set<number>>(new Set());
@@ -17,7 +16,7 @@
 	}
 
 	function isHidden(id: number): boolean {
-		return localHiddenIds.has(id) || hiddenIds.has(id);
+		return localHiddenIds.has(id);
 	}
 
 	async function hide(storyId: number) {

--- a/src/routes/ask/+page.svelte
+++ b/src/routes/ask/+page.svelte
@@ -3,8 +3,10 @@
 
 	let { data } = $props();
 	let votedIds = $derived(new Set(data.votedIds));
+	let hiddenIds = $derived(new Set(data.hiddenIds ?? []));
 	let localVotedIds = $state<Set<number> | null>(null);
 	let localPoints = $state<Record<number, number>>({});
+	let localHiddenIds = $state<Set<number>>(new Set());
 
 	function getVotedIds(): Set<number> {
 		return localVotedIds ?? votedIds;
@@ -12,6 +14,26 @@
 
 	function getPoints(story: { id: number; points: number }): number {
 		return localPoints[story.id] ?? story.points;
+	}
+
+	function isHidden(id: number): boolean {
+		return localHiddenIds.has(id) || hiddenIds.has(id);
+	}
+
+	async function hide(storyId: number) {
+		const res = await fetch('/api/hide', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ storyId })
+		});
+		if (res.ok) {
+			const result: { hidden: boolean } = await res.json();
+			if (result.hidden) {
+				const next = new Set(localHiddenIds);
+				next.add(storyId);
+				localHiddenIds = next;
+			}
+		}
 	}
 
 	async function vote(storyId: number) {
@@ -40,6 +62,7 @@
 
 <div class="story-list">
 	{#each data.stories as story, i}
+		{#if !isHidden(story.id)}
 		<div class="story-item">
 			<span class="story-rank">{(data.page - 1) * 30 + i + 1}.</span>
 			<span class="story-vote">
@@ -68,9 +91,13 @@
 					<a href="/item/{story.id}"
 						>{story.comment_count} comment{story.comment_count !== 1 ? 's' : ''}</a
 					>
+					{#if data.user}
+						| <a href="#hide" onclick={(e) => { e.preventDefault(); hide(story.id); }}>hide</a>
+					{/if}
 				</div>
 			</div>
 		</div>
+		{/if}
 	{/each}
 </div>
 

--- a/src/routes/best/+page.server.ts
+++ b/src/routes/best/+page.server.ts
@@ -1,23 +1,25 @@
 import type { PageServerLoad } from './$types';
-import { getDB, getStories, getVotedStoryIds } from '$lib/server/db';
+import { getDB, getStories, getVotedStoryIds, getHiddenStoryIds } from '$lib/server/db';
 
 export const load: PageServerLoad = async ({ url, platform, locals }) => {
 	const db = getDB(platform);
 	const page = parseInt(url.searchParams.get('p') || '1', 10);
-	const stories = await getStories(db, { orderBy: 'best', page, limit: 30 });
+	let stories = await getStories(db, { orderBy: 'best', page, limit: 30 });
 
 	let votedIds: Set<number> = new Set();
+	let hiddenIds: Set<number> = new Set();
 	if (locals.user) {
-		votedIds = await getVotedStoryIds(
-			db,
-			locals.user.id,
-			stories.map((s) => s.id)
-		);
+		[votedIds, hiddenIds] = await Promise.all([
+			getVotedStoryIds(db, locals.user.id, stories.map((s) => s.id)),
+			getHiddenStoryIds(db, locals.user.id)
+		]);
+		stories = stories.filter((s) => !hiddenIds.has(s.id));
 	}
 
 	return {
 		stories,
 		page,
-		votedIds: Array.from(votedIds)
+		votedIds: Array.from(votedIds),
+		hiddenIds: Array.from(hiddenIds)
 	};
 };

--- a/src/routes/best/+page.server.ts
+++ b/src/routes/best/+page.server.ts
@@ -4,7 +4,7 @@ import { getDB, getStories, getVotedStoryIds, getHiddenStoryIds } from '$lib/ser
 export const load: PageServerLoad = async ({ url, platform, locals }) => {
 	const db = getDB(platform);
 	const page = parseInt(url.searchParams.get('p') || '1', 10);
-	let stories = await getStories(db, { orderBy: 'best', page, limit: 30 });
+	let stories = await getStories(db, { orderBy: 'best', page, limit: 60 });
 
 	let votedIds: Set<number> = new Set();
 	let hiddenIds: Set<number> = new Set();
@@ -13,13 +13,12 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 			getVotedStoryIds(db, locals.user.id, stories.map((s) => s.id)),
 			getHiddenStoryIds(db, locals.user.id)
 		]);
-		stories = stories.filter((s) => !hiddenIds.has(s.id));
+		stories = stories.filter((s) => !hiddenIds.has(s.id)).slice(0, 30);
 	}
 
 	return {
 		stories,
 		page,
-		votedIds: Array.from(votedIds),
-		hiddenIds: Array.from(hiddenIds)
+		votedIds: Array.from(votedIds)
 	};
 };

--- a/src/routes/best/+page.svelte
+++ b/src/routes/best/+page.svelte
@@ -3,7 +3,6 @@
 
 	let { data } = $props();
 	let votedIds = $derived(new Set(data.votedIds));
-	let hiddenIds = $derived(new Set(data.hiddenIds ?? []));
 	let localVotedIds = $state<Set<number> | null>(null);
 	let localPoints = $state<Record<number, number>>({});
 	let localHiddenIds = $state<Set<number>>(new Set());
@@ -17,7 +16,7 @@
 	}
 
 	function isHidden(id: number): boolean {
-		return localHiddenIds.has(id) || hiddenIds.has(id);
+		return localHiddenIds.has(id);
 	}
 
 	async function hide(storyId: number) {

--- a/src/routes/best/+page.svelte
+++ b/src/routes/best/+page.svelte
@@ -3,8 +3,10 @@
 
 	let { data } = $props();
 	let votedIds = $derived(new Set(data.votedIds));
+	let hiddenIds = $derived(new Set(data.hiddenIds ?? []));
 	let localVotedIds = $state<Set<number> | null>(null);
 	let localPoints = $state<Record<number, number>>({});
+	let localHiddenIds = $state<Set<number>>(new Set());
 
 	function getVotedIds(): Set<number> {
 		return localVotedIds ?? votedIds;
@@ -12,6 +14,26 @@
 
 	function getPoints(story: { id: number; points: number }): number {
 		return localPoints[story.id] ?? story.points;
+	}
+
+	function isHidden(id: number): boolean {
+		return localHiddenIds.has(id) || hiddenIds.has(id);
+	}
+
+	async function hide(storyId: number) {
+		const res = await fetch('/api/hide', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ storyId })
+		});
+		if (res.ok) {
+			const result: { hidden: boolean } = await res.json();
+			if (result.hidden) {
+				const next = new Set(localHiddenIds);
+				next.add(storyId);
+				localHiddenIds = next;
+			}
+		}
 	}
 
 	async function vote(storyId: number) {
@@ -40,6 +62,7 @@
 
 <div class="story-list">
 	{#each data.stories as story, i}
+		{#if !isHidden(story.id)}
 		<div class="story-item">
 			<span class="story-rank">{(data.page - 1) * 30 + i + 1}.</span>
 			<span class="story-vote">
@@ -68,9 +91,13 @@
 					<a href="/item/{story.id}"
 						>{story.comment_count} comment{story.comment_count !== 1 ? 's' : ''}</a
 					>
+					{#if data.user}
+						| <a href="#hide" onclick={(e) => { e.preventDefault(); hide(story.id); }}>hide</a>
+					{/if}
 				</div>
 			</div>
 		</div>
+		{/if}
 	{/each}
 </div>
 

--- a/src/routes/front/+page.server.ts
+++ b/src/routes/front/+page.server.ts
@@ -1,5 +1,5 @@
 import type { PageServerLoad } from './$types';
-import { getDB, getFrontPageStories, getVotedStoryIds } from '$lib/server/db';
+import { getDB, getFrontPageStories, getVotedStoryIds, getHiddenStoryIds } from '$lib/server/db';
 
 export const load: PageServerLoad = async ({ url, platform, locals }) => {
 	const db = getDB(platform);
@@ -16,21 +16,23 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 		day = yesterday.toISOString().slice(0, 10);
 	}
 
-	const stories = await getFrontPageStories(db, day, page, 30);
+	let stories = await getFrontPageStories(db, day, page, 30);
 
 	let votedIds: Set<number> = new Set();
+	let hiddenIds: Set<number> = new Set();
 	if (locals.user) {
-		votedIds = await getVotedStoryIds(
-			db,
-			locals.user.id,
-			stories.map((s) => s.id)
-		);
+		[votedIds, hiddenIds] = await Promise.all([
+			getVotedStoryIds(db, locals.user.id, stories.map((s) => s.id)),
+			getHiddenStoryIds(db, locals.user.id)
+		]);
+		stories = stories.filter((s) => !hiddenIds.has(s.id));
 	}
 
 	return {
 		stories,
 		page,
 		day,
-		votedIds: Array.from(votedIds)
+		votedIds: Array.from(votedIds),
+		hiddenIds: Array.from(hiddenIds)
 	};
 };

--- a/src/routes/front/+page.server.ts
+++ b/src/routes/front/+page.server.ts
@@ -16,7 +16,7 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 		day = yesterday.toISOString().slice(0, 10);
 	}
 
-	let stories = await getFrontPageStories(db, day, page, 30);
+	let stories = await getFrontPageStories(db, day, page, 60);
 
 	let votedIds: Set<number> = new Set();
 	let hiddenIds: Set<number> = new Set();
@@ -25,14 +25,13 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 			getVotedStoryIds(db, locals.user.id, stories.map((s) => s.id)),
 			getHiddenStoryIds(db, locals.user.id)
 		]);
-		stories = stories.filter((s) => !hiddenIds.has(s.id));
+		stories = stories.filter((s) => !hiddenIds.has(s.id)).slice(0, 30);
 	}
 
 	return {
 		stories,
 		page,
 		day,
-		votedIds: Array.from(votedIds),
-		hiddenIds: Array.from(hiddenIds)
+		votedIds: Array.from(votedIds)
 	};
 };

--- a/src/routes/front/+page.svelte
+++ b/src/routes/front/+page.svelte
@@ -3,8 +3,10 @@
 
 	let { data } = $props();
 	let votedIds = $derived(new Set(data.votedIds));
+	let hiddenIds = $derived(new Set(data.hiddenIds ?? []));
 	let localVotedIds = $state<Set<number> | null>(null);
 	let localPoints = $state<Record<number, number>>({});
+	let localHiddenIds = $state<Set<number>>(new Set());
 
 	function getVotedIds(): Set<number> {
 		return localVotedIds ?? votedIds;
@@ -12,6 +14,26 @@
 
 	function getPoints(story: { id: number; points: number }): number {
 		return localPoints[story.id] ?? story.points;
+	}
+
+	function isHidden(id: number): boolean {
+		return localHiddenIds.has(id) || hiddenIds.has(id);
+	}
+
+	async function hide(storyId: number) {
+		const res = await fetch('/api/hide', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ storyId })
+		});
+		if (res.ok) {
+			const result: { hidden: boolean } = await res.json();
+			if (result.hidden) {
+				const next = new Set(localHiddenIds);
+				next.add(storyId);
+				localHiddenIds = next;
+			}
+		}
 	}
 
 	async function vote(storyId: number) {
@@ -75,6 +97,7 @@
 
 <div class="story-list">
 	{#each data.stories as story, i}
+		{#if !isHidden(story.id)}
 		<div class="story-item">
 			<span class="story-rank">{(data.page - 1) * 30 + i + 1}.</span>
 			<span class="story-vote">
@@ -103,9 +126,13 @@
 					<a href="/item/{story.id}"
 						>{story.comment_count} comment{story.comment_count !== 1 ? 's' : ''}</a
 					>
+					{#if data.user}
+						| <a href="#hide" onclick={(e) => { e.preventDefault(); hide(story.id); }}>hide</a>
+					{/if}
 				</div>
 			</div>
 		</div>
+		{/if}
 	{/each}
 </div>
 

--- a/src/routes/front/+page.svelte
+++ b/src/routes/front/+page.svelte
@@ -3,7 +3,6 @@
 
 	let { data } = $props();
 	let votedIds = $derived(new Set(data.votedIds));
-	let hiddenIds = $derived(new Set(data.hiddenIds ?? []));
 	let localVotedIds = $state<Set<number> | null>(null);
 	let localPoints = $state<Record<number, number>>({});
 	let localHiddenIds = $state<Set<number>>(new Set());
@@ -17,7 +16,7 @@
 	}
 
 	function isHidden(id: number): boolean {
-		return localHiddenIds.has(id) || hiddenIds.has(id);
+		return localHiddenIds.has(id);
 	}
 
 	async function hide(storyId: number) {

--- a/src/routes/newest/+page.server.ts
+++ b/src/routes/newest/+page.server.ts
@@ -4,7 +4,7 @@ import { getDB, getStories, getVotedStoryIds, getHiddenStoryIds } from '$lib/ser
 export const load: PageServerLoad = async ({ url, platform, locals }) => {
 	const db = getDB(platform);
 	const page = parseInt(url.searchParams.get('p') || '1', 10);
-	let stories = await getStories(db, { orderBy: 'newest', page, limit: 30 });
+	let stories = await getStories(db, { orderBy: 'newest', page, limit: 60 });
 
 	let votedIds: Set<number> = new Set();
 	let hiddenIds: Set<number> = new Set();
@@ -13,13 +13,12 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 			getVotedStoryIds(db, locals.user.id, stories.map((s) => s.id)),
 			getHiddenStoryIds(db, locals.user.id)
 		]);
-		stories = stories.filter((s) => !hiddenIds.has(s.id));
+		stories = stories.filter((s) => !hiddenIds.has(s.id)).slice(0, 30);
 	}
 
 	return {
 		stories,
 		page,
-		votedIds: Array.from(votedIds),
-		hiddenIds: Array.from(hiddenIds)
+		votedIds: Array.from(votedIds)
 	};
 };

--- a/src/routes/newest/+page.server.ts
+++ b/src/routes/newest/+page.server.ts
@@ -1,23 +1,25 @@
 import type { PageServerLoad } from './$types';
-import { getDB, getStories, getVotedStoryIds } from '$lib/server/db';
+import { getDB, getStories, getVotedStoryIds, getHiddenStoryIds } from '$lib/server/db';
 
 export const load: PageServerLoad = async ({ url, platform, locals }) => {
 	const db = getDB(platform);
 	const page = parseInt(url.searchParams.get('p') || '1', 10);
-	const stories = await getStories(db, { orderBy: 'newest', page, limit: 30 });
+	let stories = await getStories(db, { orderBy: 'newest', page, limit: 30 });
 
 	let votedIds: Set<number> = new Set();
+	let hiddenIds: Set<number> = new Set();
 	if (locals.user) {
-		votedIds = await getVotedStoryIds(
-			db,
-			locals.user.id,
-			stories.map((s) => s.id)
-		);
+		[votedIds, hiddenIds] = await Promise.all([
+			getVotedStoryIds(db, locals.user.id, stories.map((s) => s.id)),
+			getHiddenStoryIds(db, locals.user.id)
+		]);
+		stories = stories.filter((s) => !hiddenIds.has(s.id));
 	}
 
 	return {
 		stories,
 		page,
-		votedIds: Array.from(votedIds)
+		votedIds: Array.from(votedIds),
+		hiddenIds: Array.from(hiddenIds)
 	};
 };

--- a/src/routes/newest/+page.svelte
+++ b/src/routes/newest/+page.svelte
@@ -3,7 +3,6 @@
 
 	let { data } = $props();
 	let votedIds = $derived(new Set(data.votedIds));
-	let hiddenIds = $derived(new Set(data.hiddenIds ?? []));
 	let localVotedIds = $state<Set<number> | null>(null);
 	let localPoints = $state<Record<number, number>>({});
 	let localHiddenIds = $state<Set<number>>(new Set());
@@ -17,7 +16,7 @@
 	}
 
 	function isHidden(id: number): boolean {
-		return localHiddenIds.has(id) || hiddenIds.has(id);
+		return localHiddenIds.has(id);
 	}
 
 	async function hide(storyId: number) {

--- a/src/routes/newest/+page.svelte
+++ b/src/routes/newest/+page.svelte
@@ -3,8 +3,10 @@
 
 	let { data } = $props();
 	let votedIds = $derived(new Set(data.votedIds));
+	let hiddenIds = $derived(new Set(data.hiddenIds ?? []));
 	let localVotedIds = $state<Set<number> | null>(null);
 	let localPoints = $state<Record<number, number>>({});
+	let localHiddenIds = $state<Set<number>>(new Set());
 
 	function getVotedIds(): Set<number> {
 		return localVotedIds ?? votedIds;
@@ -12,6 +14,26 @@
 
 	function getPoints(story: { id: number; points: number }): number {
 		return localPoints[story.id] ?? story.points;
+	}
+
+	function isHidden(id: number): boolean {
+		return localHiddenIds.has(id) || hiddenIds.has(id);
+	}
+
+	async function hide(storyId: number) {
+		const res = await fetch('/api/hide', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ storyId })
+		});
+		if (res.ok) {
+			const result: { hidden: boolean } = await res.json();
+			if (result.hidden) {
+				const next = new Set(localHiddenIds);
+				next.add(storyId);
+				localHiddenIds = next;
+			}
+		}
 	}
 
 	async function vote(storyId: number) {
@@ -40,6 +62,7 @@
 
 <div class="story-list">
 	{#each data.stories as story, i}
+		{#if !isHidden(story.id)}
 		<div class="story-item">
 			<span class="story-rank">{(data.page - 1) * 30 + i + 1}.</span>
 			<span class="story-vote">
@@ -68,9 +91,13 @@
 					<a href="/item/{story.id}"
 						>{story.comment_count} comment{story.comment_count !== 1 ? 's' : ''}</a
 					>
+					{#if data.user}
+						| <a href="#hide" onclick={(e) => { e.preventDefault(); hide(story.id); }}>hide</a>
+					{/if}
 				</div>
 			</div>
 		</div>
+		{/if}
 	{/each}
 </div>
 

--- a/src/routes/show/+page.server.ts
+++ b/src/routes/show/+page.server.ts
@@ -4,7 +4,7 @@ import { getDB, getStories, getVotedStoryIds, getHiddenStoryIds } from '$lib/ser
 export const load: PageServerLoad = async ({ url, platform, locals }) => {
 	const db = getDB(platform);
 	const page = parseInt(url.searchParams.get('p') || '1', 10);
-	let stories = await getStories(db, { type: 'show', orderBy: 'rank', page, limit: 30 });
+	let stories = await getStories(db, { type: 'show', orderBy: 'rank', page, limit: 60 });
 
 	let votedIds: Set<number> = new Set();
 	let hiddenIds: Set<number> = new Set();
@@ -13,13 +13,12 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 			getVotedStoryIds(db, locals.user.id, stories.map((s) => s.id)),
 			getHiddenStoryIds(db, locals.user.id)
 		]);
-		stories = stories.filter((s) => !hiddenIds.has(s.id));
+		stories = stories.filter((s) => !hiddenIds.has(s.id)).slice(0, 30);
 	}
 
 	return {
 		stories,
 		page,
-		votedIds: Array.from(votedIds),
-		hiddenIds: Array.from(hiddenIds)
+		votedIds: Array.from(votedIds)
 	};
 };

--- a/src/routes/show/+page.server.ts
+++ b/src/routes/show/+page.server.ts
@@ -1,23 +1,25 @@
 import type { PageServerLoad } from './$types';
-import { getDB, getStories, getVotedStoryIds } from '$lib/server/db';
+import { getDB, getStories, getVotedStoryIds, getHiddenStoryIds } from '$lib/server/db';
 
 export const load: PageServerLoad = async ({ url, platform, locals }) => {
 	const db = getDB(platform);
 	const page = parseInt(url.searchParams.get('p') || '1', 10);
-	const stories = await getStories(db, { type: 'show', orderBy: 'rank', page, limit: 30 });
+	let stories = await getStories(db, { type: 'show', orderBy: 'rank', page, limit: 30 });
 
 	let votedIds: Set<number> = new Set();
+	let hiddenIds: Set<number> = new Set();
 	if (locals.user) {
-		votedIds = await getVotedStoryIds(
-			db,
-			locals.user.id,
-			stories.map((s) => s.id)
-		);
+		[votedIds, hiddenIds] = await Promise.all([
+			getVotedStoryIds(db, locals.user.id, stories.map((s) => s.id)),
+			getHiddenStoryIds(db, locals.user.id)
+		]);
+		stories = stories.filter((s) => !hiddenIds.has(s.id));
 	}
 
 	return {
 		stories,
 		page,
-		votedIds: Array.from(votedIds)
+		votedIds: Array.from(votedIds),
+		hiddenIds: Array.from(hiddenIds)
 	};
 };

--- a/src/routes/show/+page.svelte
+++ b/src/routes/show/+page.svelte
@@ -3,7 +3,6 @@
 
 	let { data } = $props();
 	let votedIds = $derived(new Set(data.votedIds));
-	let hiddenIds = $derived(new Set(data.hiddenIds ?? []));
 	let localVotedIds = $state<Set<number> | null>(null);
 	let localPoints = $state<Record<number, number>>({});
 	let localHiddenIds = $state<Set<number>>(new Set());
@@ -17,7 +16,7 @@
 	}
 
 	function isHidden(id: number): boolean {
-		return localHiddenIds.has(id) || hiddenIds.has(id);
+		return localHiddenIds.has(id);
 	}
 
 	async function hide(storyId: number) {

--- a/src/routes/show/+page.svelte
+++ b/src/routes/show/+page.svelte
@@ -3,8 +3,10 @@
 
 	let { data } = $props();
 	let votedIds = $derived(new Set(data.votedIds));
+	let hiddenIds = $derived(new Set(data.hiddenIds ?? []));
 	let localVotedIds = $state<Set<number> | null>(null);
 	let localPoints = $state<Record<number, number>>({});
+	let localHiddenIds = $state<Set<number>>(new Set());
 
 	function getVotedIds(): Set<number> {
 		return localVotedIds ?? votedIds;
@@ -12,6 +14,26 @@
 
 	function getPoints(story: { id: number; points: number }): number {
 		return localPoints[story.id] ?? story.points;
+	}
+
+	function isHidden(id: number): boolean {
+		return localHiddenIds.has(id) || hiddenIds.has(id);
+	}
+
+	async function hide(storyId: number) {
+		const res = await fetch('/api/hide', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ storyId })
+		});
+		if (res.ok) {
+			const result: { hidden: boolean } = await res.json();
+			if (result.hidden) {
+				const next = new Set(localHiddenIds);
+				next.add(storyId);
+				localHiddenIds = next;
+			}
+		}
 	}
 
 	async function vote(storyId: number) {
@@ -40,6 +62,7 @@
 
 <div class="story-list">
 	{#each data.stories as story, i}
+		{#if !isHidden(story.id)}
 		<div class="story-item">
 			<span class="story-rank">{(data.page - 1) * 30 + i + 1}.</span>
 			<span class="story-vote">
@@ -68,9 +91,13 @@
 					<a href="/item/{story.id}"
 						>{story.comment_count} comment{story.comment_count !== 1 ? 's' : ''}</a
 					>
+					{#if data.user}
+						| <a href="#hide" onclick={(e) => { e.preventDefault(); hide(story.id); }}>hide</a>
+					{/if}
 				</div>
 			</div>
 		</div>
+		{/if}
 	{/each}
 </div>
 

--- a/src/routes/user/[id]/+page.svelte
+++ b/src/routes/user/[id]/+page.svelte
@@ -52,5 +52,9 @@
 		<a href="/user/{data.profile.username}/submissions">submissions</a><br />
 		<a href="/user/{data.profile.username}/comments">comments</a><br />
 		<a href="/user/{data.profile.username}/favorites">favorites</a>
+		{#if data.isOwnProfile}
+			<br />
+			<a href="/user/{data.profile.username}/hidden">hidden</a>
+		{/if}
 	</div>
 </div>

--- a/src/routes/user/[id]/hidden/+page.server.ts
+++ b/src/routes/user/[id]/hidden/+page.server.ts
@@ -1,0 +1,36 @@
+import type { PageServerLoad } from './$types';
+import { getDB, getUserByUsername, getHiddenStoriesByUserId, getVotedStoryIds } from '$lib/server/db';
+import { error } from '@sveltejs/kit';
+
+export const load: PageServerLoad = async ({ params, url, platform, locals }) => {
+	const db = getDB(platform);
+	const username = params.id;
+	const page = parseInt(url.searchParams.get('p') || '1', 10);
+
+	const user = await getUserByUsername(db, username);
+	if (!user) {
+		throw error(404, 'User not found');
+	}
+
+	if (!locals.user || locals.user.username !== username) {
+		throw error(403, 'Forbidden');
+	}
+
+	const hidden = await getHiddenStoriesByUserId(db, user.id, page, 30);
+
+	let votedIds: Set<number> = new Set();
+	if (locals.user) {
+		votedIds = await getVotedStoryIds(
+			db,
+			locals.user.id,
+			hidden.map((s) => s.id)
+		);
+	}
+
+	return {
+		username: user.username,
+		hidden,
+		votedIds: Array.from(votedIds),
+		page
+	};
+};

--- a/src/routes/user/[id]/hidden/+page.svelte
+++ b/src/routes/user/[id]/hidden/+page.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+	import { timeAgo, extractDomain, isNewUser } from '$lib/ranking';
+
+	let { data } = $props();
+	let votedIds = $derived(new Set(data.votedIds));
+	let localVotedIds = $state<Set<number> | null>(null);
+	let localPoints = $state<Record<number, number>>({});
+	let localUnhiddenIds = $state<Set<number>>(new Set());
+
+	function getVotedIds(): Set<number> {
+		return localVotedIds ?? votedIds;
+	}
+
+	function getPoints(story: { id: number; points: number }): number {
+		return localPoints[story.id] ?? story.points;
+	}
+
+	function isUnhidden(id: number): boolean {
+		return localUnhiddenIds.has(id);
+	}
+
+	async function unhide(storyId: number) {
+		const res = await fetch('/api/hide', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ storyId })
+		});
+		if (res.ok) {
+			const result: { hidden: boolean } = await res.json();
+			if (!result.hidden) {
+				const next = new Set(localUnhiddenIds);
+				next.add(storyId);
+				localUnhiddenIds = next;
+			}
+		}
+	}
+
+	async function vote(storyId: number) {
+		if (!data.user) {
+			window.location.href = '/login';
+			return;
+		}
+		const res = await fetch('/api/vote', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
+		});
+		if (res.ok) {
+			const result: { voted: boolean; points: number } = await res.json();
+			localPoints = { ...localPoints, [storyId]: result.points };
+			const next = new Set(getVotedIds());
+			if (result.voted) {
+				next.add(storyId);
+			} else {
+				next.delete(storyId);
+			}
+			localVotedIds = next;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>{data.username}'s hidden | ハッカーのろし</title>
+</svelte:head>
+
+<div class="story-list" style="padding-left: 40px;">
+	{#each data.hidden as story, i}
+		{#if !isUnhidden(story.id)}
+		<div class="story-item">
+			<span class="story-rank">{(data.page - 1) * 30 + i + 1}.</span>
+			<span class="story-vote">
+				<button
+					class="upvote"
+					class:voted={getVotedIds().has(story.id)}
+					onclick={() => vote(story.id)}
+					aria-label="upvote"
+				>
+					&#9650;
+				</button>
+			</span>
+			<div class="story-content">
+				<div class="story-title-line">
+					{#if story.url}
+						<a href={story.url} class="story-title">{story.title}</a>
+						<span class="story-domain">({extractDomain(story.url)})</span>
+					{:else}
+						<a href="/item/{story.id}" class="story-title">{story.title}</a>
+					{/if}
+				</div>
+				<div class="story-meta">
+					{getPoints(story)} point{getPoints(story) !== 1 ? 's' : ''} by
+					<a href="/user/{story.username}" style={isNewUser(story.user_created_at) ? 'color: #3c963c;' : ''}>{story.username}</a>
+					<a href="/item/{story.id}">{timeAgo(story.created_at)}</a> |
+					<a href="/item/{story.id}"
+						>{story.comment_count} comment{story.comment_count !== 1 ? 's' : ''}</a
+					>
+					| <a href="#unhide" onclick={(e) => { e.preventDefault(); unhide(story.id); }}>un-hide</a>
+				</div>
+			</div>
+		</div>
+		{/if}
+	{/each}
+</div>
+
+{#if data.hidden.length === 30}
+	<div class="more-link">
+		<a href="/user/{data.username}/hidden?p={data.page + 1}">More</a>
+	</div>
+{/if}


### PR DESCRIPTION
## 関連 Issue
closes #18

## 変更内容
- `hidden` テーブル追加（user_id, story_id 複合PK）
- DB関数追加: `hasHidden`, `getHiddenStoryIds`, `getHiddenStoriesByUserId`
- `/api/hide` エンドポイント追加（POST トグル）
- 全7ストーリー一覧ページでhiddenストーリーをサーバーサイド除外
- 全7ストーリー一覧ページに `hide` テキストリンク追加（ログイン時のみ、クリックで即非表示）
- `/user/[id]/hidden` 一覧ページ追加（本人のみ、unhide付き）
- プロフィールページに hidden リンク追加（本人のみ）
- docs/spec.md, docs/architecture.md 更新