### PR TITLE
feat: #20 downvote機能を追加

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -35,6 +35,7 @@ CREATE TABLE IF NOT EXISTS votes (
   user_id INTEGER NOT NULL REFERENCES users(id),
   item_id INTEGER NOT NULL,
   item_type TEXT NOT NULL CHECK (item_type IN ('story', 'comment')),
+  vote_type TEXT NOT NULL DEFAULT 'up' CHECK (vote_type IN ('up', 'down')),
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
   PRIMARY KEY (user_id, item_id, item_type)
 );

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -111,6 +111,7 @@ hacker-noroshi/
 | user_id | INTEGER FK | |
 | item_id | INTEGER | story or comment の id |
 | item_type | TEXT | 'story' or 'comment' |
+| vote_type | TEXT | 'up' or 'down'（デフォルト 'up'） |
 | created_at | TEXT | ISO8601 |
 | PRIMARY KEY | (user_id, item_id, item_type) | 重複投票防止 |
 
@@ -187,9 +188,9 @@ hacker-noroshi/
 | `getCommentsByUserId()` | ユーザーのコメント一覧（story_title 付き） |
 | `getActiveStories()` | アクティブな議論（最新コメント時刻順にストーリーをソート） |
 | `getRecentComments()` | 全ストーリーの最新コメント一覧（/newcomments 用） |
-| `hasVoted()` | 投票済みチェック |
-| `getVotedStoryIds()` | 投票済みストーリーID一括取得 |
-| `getVotedCommentIds()` | 投票済みコメントID一括取得 |
+| `getVoteState()` | 投票状態取得（'up' / 'down' / null） |
+| `getVotedStoryIds()` | upvote済みストーリーID一括取得 |
+| `getCommentVoteStates()` | コメント投票状態一括取得（Map<id, 'up'/'down'>） |
 | `hasFavorited()` | お気に入り済みチェック |
 | `getFavoriteStoryIds()` | お気に入り済みストーリーID一括取得 |
 | `getFavoriteStoriesByUserId()` | ユーザーのお気に入りストーリー一覧 |

--- a/docs/design.md
+++ b/docs/design.md
@@ -14,10 +14,10 @@ Hardcoded CSS values. No variables, no tokens.
 
 | Color     | Hex       | Usage                              |
 | --------- | --------- | ---------------------------------- |
-| Orange    | `#ff6600` | Header bg, voted indicator, hover  |
+| Orange    | `#ff6600` | Header bg, voted indicator (up/down), hover |
 | Cream     | `#f6f6ef` | Page background                    |
 | Black     | `#000000` | Primary text, titles               |
-| Gray      | `#828282` | Meta text, timestamps, visited links |
+| Gray      | `#828282` | Meta text, timestamps, visited links, faded comments (downvoted) |
 | Light gray | `#9a9a9a` | Inactive upvote arrow              |
 | Red       | `#ff0000` | Error messages                     |
 | White     | `#ffffff` | Header text, logo border           |
@@ -70,7 +70,10 @@ Base font size is `10pt` on html/body. Everything is in `pt`, not `rem` or `px`.
 
 - Nesting: `40px` left padding per depth level
 - Head: `7pt`, `#828282`
+- Upvote: `▲` (`&#9650;`), `8pt`, default `#9a9a9a`, hover/voted `#ff6600`
+- Downvote: `▼` (`&#9660;`), `8pt`, default `#9a9a9a`, hover/voted `#ff6600`（karma >= 500 のみ表示）
 - Text: `9pt`, `#000000`, line-height `14pt`
+- Faded text: `#828282`（points < 1 のコメント）
 - Reply link: `7pt`, `#828282`, underline
 
 ### Forms

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -29,10 +29,18 @@ URL: https://hn.llll-ll.com
 
 ### 投票
 
-- upvote のみ（downvote なし、v1）
-- ストーリーとコメントの両方に投票可能
-- トグル式（再クリックで取り消し）
+- ストーリー: upvote のみ
+- コメント: upvote + downvote
+- トグル式（再クリックで取り消し、逆方向クリックで切替）
 - 重複投票は PK 制約で防止
+
+#### downvote（コメント専用）
+
+- karma 500 以上のユーザーのみ downvote 可能
+- ストーリーへの downvote は不可
+- 自分のコメントへの直接返信には downvote 不可
+- downvote されたコメント（points < 1）はテキストがフェード表示（薄い色）
+- downvote 済みの ▼ はオレンジ色で表示
 
 ### ランキングアルゴリズム
 
@@ -97,6 +105,7 @@ score = (points - 1) / (hours_since_post + 2) ^ 1.8
 - [x] APIドキュメントページ追加（/api-docs、フッターからリンク）
 - [x] favorites 機能（favorite/un-fav トグル + /user/[id]/favorites 一覧）
 - [x] hide 機能（ストーリー非表示 + /user/[id]/hidden 一覧 + 一覧からの除外）
+- [x] downvote 機能（コメント専用、karma 500 閾値、フェード表示）
 
 ## v2 以降
 

--- a/src/app.css
+++ b/src/app.css
@@ -348,7 +348,8 @@ a:hover {
 }
 
 .comment-head .downvote {
-	font-size: 8px;
+	display: inline;
+	font-size: 8pt;
 	color: #9a9a9a;
 	cursor: pointer;
 	background: none;
@@ -366,16 +367,16 @@ a:hover {
 	color: #ff6600;
 }
 
-.comment-text.faded {
-	color: #dddddd;
-}
-
 .comment-text {
 	font-size: 9pt;
 	color: #000000;
 	margin-top: 3px;
 	line-height: 14pt;
 	overflow-wrap: break-word;
+}
+
+.comment-text.faded {
+	color: #828282;
 }
 
 .comment-text p {

--- a/src/app.css
+++ b/src/app.css
@@ -347,6 +347,29 @@ a:hover {
 	color: #ff6600;
 }
 
+.comment-head .downvote {
+	font-size: 8px;
+	color: #9a9a9a;
+	cursor: pointer;
+	background: none;
+	border: none;
+	padding: 0;
+	line-height: 1;
+	font-family: Verdana, Geneva, sans-serif;
+}
+
+.comment-head .downvote:hover {
+	color: #ff6600;
+}
+
+.comment-head .downvote.voted {
+	color: #ff6600;
+}
+
+.comment-text.faded {
+	color: #dddddd;
+}
+
 .comment-text {
 	font-size: 9pt;
 	color: #000000;

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -209,17 +209,18 @@ export async function getStoriesByUserId(
 	return result.results;
 }
 
-export async function hasVoted(
+export async function getVoteState(
 	db: D1Database,
 	userId: number,
 	itemId: number,
 	itemType: string
-): Promise<boolean> {
+): Promise<'up' | 'down' | null> {
 	const result = await db
-		.prepare('SELECT 1 FROM votes WHERE user_id = ? AND item_id = ? AND item_type = ?')
+		.prepare('SELECT vote_type FROM votes WHERE user_id = ? AND item_id = ? AND item_type = ?')
 		.bind(userId, itemId, itemType)
-		.first();
-	return result !== null;
+		.first<{ vote_type: string }>();
+	if (!result) return null;
+	return result.vote_type as 'up' | 'down';
 }
 
 export async function getVotedStoryIds(
@@ -231,7 +232,7 @@ export async function getVotedStoryIds(
 	const placeholders = storyIds.map(() => '?').join(',');
 	const result = await db
 		.prepare(
-			`SELECT item_id FROM votes WHERE user_id = ? AND item_type = 'story' AND item_id IN (${placeholders})`
+			`SELECT item_id FROM votes WHERE user_id = ? AND item_type = 'story' AND vote_type = 'up' AND item_id IN (${placeholders})`
 		)
 		.bind(userId, ...storyIds)
 		.all<{ item_id: number }>();
@@ -295,20 +296,24 @@ export async function getChildComments(
 	return all.filter((c) => childIds.has(c.id));
 }
 
-export async function getVotedCommentIds(
+export async function getCommentVoteStates(
 	db: D1Database,
 	userId: number,
 	commentIds: number[]
-): Promise<Set<number>> {
-	if (commentIds.length === 0) return new Set();
+): Promise<Map<number, 'up' | 'down'>> {
+	if (commentIds.length === 0) return new Map();
 	const placeholders = commentIds.map(() => '?').join(',');
 	const result = await db
 		.prepare(
-			`SELECT item_id FROM votes WHERE user_id = ? AND item_type = 'comment' AND item_id IN (${placeholders})`
+			`SELECT item_id, vote_type FROM votes WHERE user_id = ? AND item_type = 'comment' AND item_id IN (${placeholders})`
 		)
 		.bind(userId, ...commentIds)
-		.all<{ item_id: number }>();
-	return new Set(result.results.map((r) => r.item_id));
+		.all<{ item_id: number; vote_type: string }>();
+	const map = new Map<number, 'up' | 'down'>();
+	for (const r of result.results) {
+		map.set(r.item_id, r.vote_type as 'up' | 'down');
+	}
+	return map;
 }
 
 export async function getActiveStories(

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -46,10 +46,10 @@
 			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
 		});
 		if (res.ok) {
-			const result: { voted: boolean; points: number } = await res.json();
+			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
 			localPoints = { ...localPoints, [storyId]: result.points };
 			const next = new Set(getVotedIds());
-			if (result.voted) {
+			if (result.voteState === 'up') {
 				next.add(storyId);
 			} else {
 				next.delete(storyId);

--- a/src/routes/active/+page.svelte
+++ b/src/routes/active/+page.svelte
@@ -46,10 +46,10 @@
 			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
 		});
 		if (res.ok) {
-			const result: { voted: boolean; points: number } = await res.json();
+			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
 			localPoints = { ...localPoints, [storyId]: result.points };
 			const next = new Set(getVotedIds());
-			if (result.voted) {
+			if (result.voteState === 'up') {
 				next.add(storyId);
 			} else {
 				next.delete(storyId);

--- a/src/routes/api/vote/+server.ts
+++ b/src/routes/api/vote/+server.ts
@@ -1,6 +1,6 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { getDB, hasVoted } from '$lib/server/db';
+import { getDB, getVoteState, getCommentById } from '$lib/server/db';
 
 export const POST: RequestHandler = async ({ request, platform, locals }) => {
 	if (!locals.user) {
@@ -8,80 +8,121 @@ export const POST: RequestHandler = async ({ request, platform, locals }) => {
 	}
 
 	const db = getDB(platform);
-	const body = (await request.json()) as { itemId: number; itemType: string };
+	const body = (await request.json()) as { itemId: number; itemType: string; direction?: string };
 	const { itemId, itemType } = body;
+	const direction = body.direction === 'down' ? 'down' : 'up';
 
 	if (!itemId || !itemType || !['story', 'comment'].includes(itemType)) {
 		return json({ error: 'Invalid request' }, { status: 400 });
 	}
 
-	const alreadyVoted = await hasVoted(db, locals.user.id, itemId, itemType);
+	// Downvote restrictions
+	if (direction === 'down') {
+		// Only comments can be downvoted
+		if (itemType !== 'comment') {
+			return json({ error: 'Stories cannot be downvoted' }, { status: 400 });
+		}
 
-	if (alreadyVoted) {
-		// Remove vote
+		// Karma check
+		if (locals.user.karma < 500) {
+			return json({ error: 'Insufficient karma for downvoting' }, { status: 403 });
+		}
+
+		// Cannot downvote direct replies to own comments
+		const comment = await getCommentById(db, itemId);
+		if (comment && comment.parent_id) {
+			const parentComment = await getCommentById(db, comment.parent_id);
+			if (parentComment && parentComment.user_id === locals.user.id) {
+				return json({ error: 'Cannot downvote replies to your own comments' }, { status: 403 });
+			}
+		}
+	}
+
+	const currentVote = await getVoteState(db, locals.user.id, itemId, itemType);
+	const table = itemType === 'story' ? 'stories' : 'comments';
+
+	// Get author for karma updates
+	const authorRow = await db
+		.prepare(`SELECT user_id as uid FROM ${table} WHERE id = ?`)
+		.bind(itemId)
+		.first<{ uid: number }>();
+
+	if (currentVote === null) {
+		// No existing vote → add new vote
+		await db
+			.prepare('INSERT INTO votes (user_id, item_id, item_type, vote_type) VALUES (?, ?, ?, ?)')
+			.bind(locals.user.id, itemId, itemType, direction)
+			.run();
+
+		const pointsDelta = direction === 'up' ? 1 : -1;
+		await db
+			.prepare(`UPDATE ${table} SET points = points + ? WHERE id = ?`)
+			.bind(pointsDelta, itemId)
+			.run();
+
+		if (authorRow) {
+			await db
+				.prepare('UPDATE users SET karma = karma + ? WHERE id = ?')
+				.bind(pointsDelta, authorRow.uid)
+				.run();
+		}
+	} else if (currentVote === direction) {
+		// Same direction → remove vote (toggle off)
 		await db
 			.prepare('DELETE FROM votes WHERE user_id = ? AND item_id = ? AND item_type = ?')
 			.bind(locals.user.id, itemId, itemType)
 			.run();
 
-		// Decrement points
-		const table = itemType === 'story' ? 'stories' : 'comments';
+		const pointsDelta = direction === 'up' ? -1 : 1;
 		await db
-			.prepare(`UPDATE ${table} SET points = points - 1 WHERE id = ?`)
-			.bind(itemId)
+			.prepare(`UPDATE ${table} SET points = points + ? WHERE id = ?`)
+			.bind(pointsDelta, itemId)
 			.run();
 
-		// Get updated points
-		const row = await db
-			.prepare(`SELECT points FROM ${table} WHERE id = ?`)
-			.bind(itemId)
-			.first<{ points: number }>();
-
-		// Update karma for the item's author
-		const authorRow = await db
-			.prepare(`SELECT user_id as uid FROM ${table} WHERE id = ?`)
-			.bind(itemId)
-			.first<{ uid: number }>();
 		if (authorRow) {
 			await db
-				.prepare('UPDATE users SET karma = karma - 1 WHERE id = ?')
-				.bind(authorRow.uid)
+				.prepare('UPDATE users SET karma = karma + ? WHERE id = ?')
+				.bind(pointsDelta, authorRow.uid)
 				.run();
 		}
-
-		return json({ voted: false, points: row?.points ?? 0 });
 	} else {
-		// Add vote
+		// Opposite direction → switch vote
 		await db
-			.prepare('INSERT INTO votes (user_id, item_id, item_type) VALUES (?, ?, ?)')
-			.bind(locals.user.id, itemId, itemType)
+			.prepare(
+				'UPDATE votes SET vote_type = ?, created_at = strftime(\'%Y-%m-%dT%H:%M:%SZ\', \'now\') WHERE user_id = ? AND item_id = ? AND item_type = ?'
+			)
+			.bind(direction, locals.user.id, itemId, itemType)
 			.run();
 
-		// Increment points
-		const table = itemType === 'story' ? 'stories' : 'comments';
+		const pointsDelta = direction === 'up' ? 2 : -2;
 		await db
-			.prepare(`UPDATE ${table} SET points = points + 1 WHERE id = ?`)
-			.bind(itemId)
+			.prepare(`UPDATE ${table} SET points = points + ? WHERE id = ?`)
+			.bind(pointsDelta, itemId)
 			.run();
 
-		// Get updated points
-		const row = await db
-			.prepare(`SELECT points FROM ${table} WHERE id = ?`)
-			.bind(itemId)
-			.first<{ points: number }>();
-
-		// Update karma for the item's author
-		const authorRow = await db
-			.prepare(`SELECT user_id as uid FROM ${table} WHERE id = ?`)
-			.bind(itemId)
-			.first<{ uid: number }>();
 		if (authorRow) {
 			await db
-				.prepare('UPDATE users SET karma = karma + 1 WHERE id = ?')
-				.bind(authorRow.uid)
+				.prepare('UPDATE users SET karma = karma + ? WHERE id = ?')
+				.bind(pointsDelta, authorRow.uid)
 				.run();
 		}
-
-		return json({ voted: true, points: row?.points ?? 1 });
 	}
+
+	// Get updated points
+	const row = await db
+		.prepare(`SELECT points FROM ${table} WHERE id = ?`)
+		.bind(itemId)
+		.first<{ points: number }>();
+
+	// Determine new vote state
+	let voteState: 'up' | 'down' | null;
+	if (currentVote === null) {
+		voteState = direction;
+	} else if (currentVote === direction) {
+		voteState = null;
+	} else {
+		voteState = direction;
+	}
+
+	return json({ voteState, points: row?.points ?? 0 });
 };

--- a/src/routes/api/vote/+server.ts
+++ b/src/routes/api/vote/+server.ts
@@ -28,8 +28,13 @@ export const POST: RequestHandler = async ({ request, platform, locals }) => {
 			return json({ error: 'Insufficient karma for downvoting' }, { status: 403 });
 		}
 
-		// Cannot downvote direct replies to own comments
+		// Cannot downvote own comments
 		const comment = await getCommentById(db, itemId);
+		if (comment && comment.user_id === locals.user.id) {
+			return json({ error: 'Cannot downvote your own comments' }, { status: 403 });
+		}
+
+		// Cannot downvote direct replies to own comments
 		if (comment && comment.parent_id) {
 			const parentComment = await getCommentById(db, comment.parent_id);
 			if (parentComment && parentComment.user_id === locals.user.id) {
@@ -49,63 +54,53 @@ export const POST: RequestHandler = async ({ request, platform, locals }) => {
 
 	if (currentVote === null) {
 		// No existing vote → add new vote
-		await db
-			.prepare('INSERT INTO votes (user_id, item_id, item_type, vote_type) VALUES (?, ?, ?, ?)')
-			.bind(locals.user.id, itemId, itemType, direction)
-			.run();
-
 		const pointsDelta = direction === 'up' ? 1 : -1;
-		await db
-			.prepare(`UPDATE ${table} SET points = points + ? WHERE id = ?`)
-			.bind(pointsDelta, itemId)
-			.run();
-
+		const stmts = [
+			db.prepare('INSERT INTO votes (user_id, item_id, item_type, vote_type) VALUES (?, ?, ?, ?)')
+				.bind(locals.user.id, itemId, itemType, direction),
+			db.prepare(`UPDATE ${table} SET points = points + ? WHERE id = ?`)
+				.bind(pointsDelta, itemId)
+		];
 		if (authorRow) {
-			await db
-				.prepare('UPDATE users SET karma = karma + ? WHERE id = ?')
-				.bind(pointsDelta, authorRow.uid)
-				.run();
+			stmts.push(
+				db.prepare('UPDATE users SET karma = karma + ? WHERE id = ?')
+					.bind(pointsDelta, authorRow.uid)
+			);
 		}
+		await db.batch(stmts);
 	} else if (currentVote === direction) {
 		// Same direction → remove vote (toggle off)
-		await db
-			.prepare('DELETE FROM votes WHERE user_id = ? AND item_id = ? AND item_type = ?')
-			.bind(locals.user.id, itemId, itemType)
-			.run();
-
 		const pointsDelta = direction === 'up' ? -1 : 1;
-		await db
-			.prepare(`UPDATE ${table} SET points = points + ? WHERE id = ?`)
-			.bind(pointsDelta, itemId)
-			.run();
-
+		const stmts = [
+			db.prepare('DELETE FROM votes WHERE user_id = ? AND item_id = ? AND item_type = ?')
+				.bind(locals.user.id, itemId, itemType),
+			db.prepare(`UPDATE ${table} SET points = points + ? WHERE id = ?`)
+				.bind(pointsDelta, itemId)
+		];
 		if (authorRow) {
-			await db
-				.prepare('UPDATE users SET karma = karma + ? WHERE id = ?')
-				.bind(pointsDelta, authorRow.uid)
-				.run();
+			stmts.push(
+				db.prepare('UPDATE users SET karma = karma + ? WHERE id = ?')
+					.bind(pointsDelta, authorRow.uid)
+			);
 		}
+		await db.batch(stmts);
 	} else {
 		// Opposite direction → switch vote
-		await db
-			.prepare(
-				'UPDATE votes SET vote_type = ?, created_at = strftime(\'%Y-%m-%dT%H:%M:%SZ\', \'now\') WHERE user_id = ? AND item_id = ? AND item_type = ?'
-			)
-			.bind(direction, locals.user.id, itemId, itemType)
-			.run();
-
 		const pointsDelta = direction === 'up' ? 2 : -2;
-		await db
-			.prepare(`UPDATE ${table} SET points = points + ? WHERE id = ?`)
-			.bind(pointsDelta, itemId)
-			.run();
-
+		const stmts = [
+			db.prepare(
+				'UPDATE votes SET vote_type = ?, created_at = strftime(\'%Y-%m-%dT%H:%M:%SZ\', \'now\') WHERE user_id = ? AND item_id = ? AND item_type = ?'
+			).bind(direction, locals.user.id, itemId, itemType),
+			db.prepare(`UPDATE ${table} SET points = points + ? WHERE id = ?`)
+				.bind(pointsDelta, itemId)
+		];
 		if (authorRow) {
-			await db
-				.prepare('UPDATE users SET karma = karma + ? WHERE id = ?')
-				.bind(pointsDelta, authorRow.uid)
-				.run();
+			stmts.push(
+				db.prepare('UPDATE users SET karma = karma + ? WHERE id = ?')
+					.bind(pointsDelta, authorRow.uid)
+			);
 		}
+		await db.batch(stmts);
 	}
 
 	// Get updated points

--- a/src/routes/api/vote/+server.ts
+++ b/src/routes/api/vote/+server.ts
@@ -53,51 +53,51 @@ export const POST: RequestHandler = async ({ request, platform, locals }) => {
 		.first<{ uid: number }>();
 
 	if (currentVote === null) {
-		// No existing vote → add new vote
-		const pointsDelta = direction === 'up' ? 1 : -1;
+		// No existing vote → add new vote (points and karma move together)
+		const delta = direction === 'up' ? 1 : -1;
 		const stmts = [
 			db.prepare('INSERT INTO votes (user_id, item_id, item_type, vote_type) VALUES (?, ?, ?, ?)')
 				.bind(locals.user.id, itemId, itemType, direction),
 			db.prepare(`UPDATE ${table} SET points = points + ? WHERE id = ?`)
-				.bind(pointsDelta, itemId)
+				.bind(delta, itemId)
 		];
 		if (authorRow) {
 			stmts.push(
 				db.prepare('UPDATE users SET karma = karma + ? WHERE id = ?')
-					.bind(pointsDelta, authorRow.uid)
+					.bind(delta, authorRow.uid)
 			);
 		}
 		await db.batch(stmts);
 	} else if (currentVote === direction) {
-		// Same direction → remove vote (toggle off)
-		const pointsDelta = direction === 'up' ? -1 : 1;
+		// Same direction → remove vote (undo: points and karma move together)
+		const delta = direction === 'up' ? -1 : 1;
 		const stmts = [
 			db.prepare('DELETE FROM votes WHERE user_id = ? AND item_id = ? AND item_type = ?')
 				.bind(locals.user.id, itemId, itemType),
 			db.prepare(`UPDATE ${table} SET points = points + ? WHERE id = ?`)
-				.bind(pointsDelta, itemId)
+				.bind(delta, itemId)
 		];
 		if (authorRow) {
 			stmts.push(
 				db.prepare('UPDATE users SET karma = karma + ? WHERE id = ?')
-					.bind(pointsDelta, authorRow.uid)
+					.bind(delta, authorRow.uid)
 			);
 		}
 		await db.batch(stmts);
 	} else {
-		// Opposite direction → switch vote
-		const pointsDelta = direction === 'up' ? 2 : -2;
+		// Opposite direction → switch vote (±2: undo old + apply new, points and karma move together)
+		const delta = direction === 'up' ? 2 : -2;
 		const stmts = [
 			db.prepare(
 				'UPDATE votes SET vote_type = ?, created_at = strftime(\'%Y-%m-%dT%H:%M:%SZ\', \'now\') WHERE user_id = ? AND item_id = ? AND item_type = ?'
 			).bind(direction, locals.user.id, itemId, itemType),
 			db.prepare(`UPDATE ${table} SET points = points + ? WHERE id = ?`)
-				.bind(pointsDelta, itemId)
+				.bind(delta, itemId)
 		];
 		if (authorRow) {
 			stmts.push(
 				db.prepare('UPDATE users SET karma = karma + ? WHERE id = ?')
-					.bind(pointsDelta, authorRow.uid)
+					.bind(delta, authorRow.uid)
 			);
 		}
 		await db.batch(stmts);

--- a/src/routes/ask/+page.svelte
+++ b/src/routes/ask/+page.svelte
@@ -46,10 +46,10 @@
 			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
 		});
 		if (res.ok) {
-			const result: { voted: boolean; points: number } = await res.json();
+			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
 			localPoints = { ...localPoints, [storyId]: result.points };
 			const next = new Set(getVotedIds());
-			if (result.voted) {
+			if (result.voteState === 'up') {
 				next.add(storyId);
 			} else {
 				next.delete(storyId);

--- a/src/routes/best/+page.svelte
+++ b/src/routes/best/+page.svelte
@@ -46,10 +46,10 @@
 			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
 		});
 		if (res.ok) {
-			const result: { voted: boolean; points: number } = await res.json();
+			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
 			localPoints = { ...localPoints, [storyId]: result.points };
 			const next = new Set(getVotedIds());
-			if (result.voted) {
+			if (result.voteState === 'up') {
 				next.add(storyId);
 			} else {
 				next.delete(storyId);

--- a/src/routes/front/+page.svelte
+++ b/src/routes/front/+page.svelte
@@ -46,10 +46,10 @@
 			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
 		});
 		if (res.ok) {
-			const result: { voted: boolean; points: number } = await res.json();
+			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
 			localPoints = { ...localPoints, [storyId]: result.points };
 			const next = new Set(getVotedIds());
-			if (result.voted) {
+			if (result.voteState === 'up') {
 				next.add(storyId);
 			} else {
 				next.delete(storyId);

--- a/src/routes/item/[id]/+page.server.ts
+++ b/src/routes/item/[id]/+page.server.ts
@@ -1,5 +1,5 @@
 import type { PageServerLoad, Actions } from './$types';
-import { getDB, getStoryById, getCommentsByStoryId, getCommentById, getChildComments, getVotedCommentIds, hasVoted, hasFavorited } from '$lib/server/db';
+import { getDB, getStoryById, getCommentsByStoryId, getCommentById, getChildComments, getCommentVoteStates, getVoteState, hasFavorited } from '$lib/server/db';
 import { error, fail, redirect } from '@sveltejs/kit';
 
 export const load: PageServerLoad = async ({ params, platform, locals }) => {
@@ -17,14 +17,17 @@ export const load: PageServerLoad = async ({ params, platform, locals }) => {
 
 		let storyVoted = false;
 		let storyFavorited = false;
-		let votedCommentIds: Set<number> = new Set();
+		let commentVoteStates: Map<number, 'up' | 'down'> = new Map();
 
 		if (locals.user) {
-			[storyVoted, storyFavorited, votedCommentIds] = await Promise.all([
-				hasVoted(db, locals.user.id, id, 'story'),
+			const [storyVoteState, fav, cvs] = await Promise.all([
+				getVoteState(db, locals.user.id, id, 'story'),
 				hasFavorited(db, locals.user.id, id),
-				getVotedCommentIds(db, locals.user.id, comments.map((c) => c.id))
+				getCommentVoteStates(db, locals.user.id, comments.map((c) => c.id))
 			]);
+			storyVoted = storyVoteState === 'up';
+			storyFavorited = fav;
+			commentVoteStates = cvs;
 		}
 
 		return {
@@ -33,7 +36,7 @@ export const load: PageServerLoad = async ({ params, platform, locals }) => {
 			comments,
 			storyVoted,
 			storyFavorited,
-			votedCommentIds: Array.from(votedCommentIds)
+			commentVoteStates: Object.fromEntries(commentVoteStates)
 		};
 	}
 
@@ -51,12 +54,12 @@ export const load: PageServerLoad = async ({ params, platform, locals }) => {
 	const childComments = await getChildComments(db, comment.id, comment.story_id);
 
 	let commentVoted = false;
-	let votedCommentIds: Set<number> = new Set();
+	let commentVoteStates: Map<number, 'up' | 'down'> = new Map();
 
 	if (locals.user) {
-		commentVoted = await hasVoted(db, locals.user.id, comment.id, 'comment');
 		const allCommentIds = [comment.id, ...childComments.map((c) => c.id)];
-		votedCommentIds = await getVotedCommentIds(db, locals.user.id, allCommentIds);
+		commentVoteStates = await getCommentVoteStates(db, locals.user.id, allCommentIds);
+		commentVoted = commentVoteStates.get(comment.id) === 'up';
 	}
 
 	return {
@@ -65,7 +68,7 @@ export const load: PageServerLoad = async ({ params, platform, locals }) => {
 		parentStory,
 		comments: childComments,
 		commentVoted,
-		votedCommentIds: Array.from(votedCommentIds)
+		commentVoteStates: Object.fromEntries(commentVoteStates)
 	};
 };
 

--- a/src/routes/item/[id]/+page.svelte
+++ b/src/routes/item/[id]/+page.svelte
@@ -7,12 +7,12 @@
 	let { data, form } = $props();
 	let localStoryVoted = $state<boolean | null>(null);
 	let localStoryPoints = $state<number | null>(null);
-	let localVotedCommentIds = $state<Set<number> | null>(null);
+	let localCommentVoteStates = $state<Record<number, 'up' | 'down' | null> | null>(null);
 	let localCommentPoints = $state<Record<number, number>>({});
 	let replyTo = $state<number | null>(null);
 	let editingStory = $state(false);
 	let editingCommentId = $state<number | null>(null);
-	let localTargetCommentVoted = $state<boolean | null>(null);
+	let localTargetCommentVoteState = $state<'up' | 'down' | null | undefined>(undefined);
 	let localTargetCommentPoints = $state<number | null>(null);
 	let localStoryFavorited = $state<boolean | null>(null);
 
@@ -25,22 +25,37 @@
 	let storyVoted = $derived(localStoryVoted ?? (data.mode === 'story' ? data.storyVoted : false));
 	let storyPoints = $derived(localStoryPoints ?? (data.mode === 'story' ? data.story.points : 0));
 	let storyFavorited = $derived(localStoryFavorited ?? (data.mode === 'story' ? data.storyFavorited : false));
-	let votedCommentIdsFromServer = $derived(new Set(data.votedCommentIds));
+	let commentVoteStatesFromServer = $derived(data.commentVoteStates as Record<number, 'up' | 'down'>);
 
-	function getVotedCommentIds(): Set<number> {
-		return localVotedCommentIds ?? votedCommentIdsFromServer;
+	function getCommentVoteState(commentId: number): 'up' | 'down' | null {
+		if (localCommentVoteStates && commentId in localCommentVoteStates) {
+			return localCommentVoteStates[commentId];
+		}
+		return commentVoteStatesFromServer[commentId] ?? null;
 	}
 
 	function getCommentPoints(comment: { id: number; points: number }): number {
 		return localCommentPoints[comment.id] ?? comment.points;
 	}
 
-	let targetCommentVoted = $derived(
-		localTargetCommentVoted ?? (data.mode === 'comment' ? getVotedCommentIds().has(data.targetComment.id) : false)
+	let targetCommentVoteState = $derived(
+		localTargetCommentVoteState !== undefined
+			? localTargetCommentVoteState
+			: (data.mode === 'comment' ? (commentVoteStatesFromServer[data.targetComment.id] ?? null) : null)
 	);
 	let targetCommentPoints = $derived(
 		localTargetCommentPoints ?? (data.mode === 'comment' ? data.targetComment.points : 0)
 	);
+
+	function canDownvote(commentUserId: number, parentId: number | null): boolean {
+		if (!data.user) return false;
+		if (data.user.karma < 500) return false;
+		// Cannot downvote direct replies to own comments (checked server-side too, but hide button)
+		// We don't have parent author info client-side for all cases, so we show the button
+		// and let the server reject if needed. But for the target comment in comment mode,
+		// we can check.
+		return true;
+	}
 
 	interface CommentNode {
 		id: number;
@@ -106,13 +121,13 @@
 			body: JSON.stringify({ itemId: data.story.id, itemType: 'story' })
 		});
 		if (res.ok) {
-			const result: { voted: boolean; points: number } = await res.json();
+			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
 			localStoryPoints = result.points;
-			localStoryVoted = result.voted;
+			localStoryVoted = result.voteState === 'up';
 		}
 	}
 
-	async function voteTargetComment() {
+	async function voteTargetComment(direction: 'up' | 'down' = 'up') {
 		if (!data.user) {
 			window.location.href = '/login';
 			return;
@@ -121,24 +136,21 @@
 		const res = await fetch('/api/vote', {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ itemId: data.targetComment.id, itemType: 'comment' })
+			body: JSON.stringify({ itemId: data.targetComment.id, itemType: 'comment', direction })
 		});
 		if (res.ok) {
-			const result: { voted: boolean; points: number } = await res.json();
+			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
 			localTargetCommentPoints = result.points;
-			localTargetCommentVoted = result.voted;
-			// Also update in the voted set
-			const next = new Set(getVotedCommentIds());
-			if (result.voted) {
-				next.add(data.targetComment.id);
-			} else {
-				next.delete(data.targetComment.id);
-			}
-			localVotedCommentIds = next;
+			localTargetCommentVoteState = result.voteState;
+			// Also update in the local states
+			localCommentVoteStates = {
+				...(localCommentVoteStates ?? {}),
+				[data.targetComment.id]: result.voteState
+			};
 		}
 	}
 
-	async function voteComment(commentId: number) {
+	async function voteComment(commentId: number, direction: 'up' | 'down' = 'up') {
 		if (!data.user) {
 			window.location.href = '/login';
 			return;
@@ -146,18 +158,15 @@
 		const res = await fetch('/api/vote', {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ itemId: commentId, itemType: 'comment' })
+			body: JSON.stringify({ itemId: commentId, itemType: 'comment', direction })
 		});
 		if (res.ok) {
-			const result: { voted: boolean; points: number } = await res.json();
+			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
 			localCommentPoints = { ...localCommentPoints, [commentId]: result.points };
-			const next = new Set(getVotedCommentIds());
-			if (result.voted) {
-				next.add(commentId);
-			} else {
-				next.delete(commentId);
-			}
-			localVotedCommentIds = next;
+			localCommentVoteStates = {
+				...(localCommentVoteStates ?? {}),
+				[commentId]: result.voteState
+			};
 		}
 	}
 
@@ -191,12 +200,22 @@
 			<span class="comment-vote">
 				<button
 					class="upvote"
-					class:voted={targetCommentVoted}
-					onclick={voteTargetComment}
+					class:voted={targetCommentVoteState === 'up'}
+					onclick={() => voteTargetComment('up')}
 					aria-label="upvote comment"
 				>
 					&#9650;
 				</button>
+				{#if data.user && data.user.karma >= 500}
+					<button
+						class="downvote"
+						class:voted={targetCommentVoteState === 'down'}
+						onclick={() => voteTargetComment('down')}
+						aria-label="downvote comment"
+					>
+						&#9660;
+					</button>
+				{/if}
 			</span>
 			<a href="/user/{comment.username}" style={isNewUser(comment.user_created_at) ? 'color: #3c963c;' : ''}>{comment.username}</a>
 			<a href="/item/{comment.id}">{timeAgo(comment.created_at)}</a>
@@ -238,7 +257,7 @@
 				</form>
 			</div>
 		{:else}
-			<div class="comment-text" style="padding-left: 14px;">
+			<div class="comment-text" class:faded={targetCommentPoints < 1} style="padding-left: 14px;">
 				{#each comment.text.split('\n') as paragraph}
 					{#if paragraph.trim()}
 						<p>{@html formatText(paragraph)}</p>
@@ -270,12 +289,22 @@
 						<span class="comment-vote">
 							<button
 								class="upvote"
-								class:voted={getVotedCommentIds().has(child.id)}
-								onclick={() => voteComment(child.id)}
+								class:voted={getCommentVoteState(child.id) === 'up'}
+								onclick={() => voteComment(child.id, 'up')}
 								aria-label="upvote comment"
 							>
 								&#9650;
 							</button>
+							{#if data.user && data.user.karma >= 500}
+								<button
+									class="downvote"
+									class:voted={getCommentVoteState(child.id) === 'down'}
+									onclick={() => voteComment(child.id, 'down')}
+									aria-label="downvote comment"
+								>
+									&#9660;
+								</button>
+							{/if}
 						</span>
 						<a href="/user/{child.username}" style={isNewUser(child.user_created_at) ? 'color: #3c963c;' : ''}>{child.username}</a>
 						<a href="/item/{child.id}">{timeAgo(child.created_at)}</a>
@@ -303,7 +332,7 @@
 							</form>
 						</div>
 					{:else}
-						<div class="comment-text" style="padding-left: 14px;">
+						<div class="comment-text" class:faded={getCommentPoints(child) < 1} style="padding-left: 14px;">
 							{#each child.text.split('\n') as paragraph}
 								{#if paragraph.trim()}
 									<p>{@html formatText(paragraph)}</p>
@@ -458,12 +487,22 @@
 						<span class="comment-vote">
 							<button
 								class="upvote"
-								class:voted={getVotedCommentIds().has(comment.id)}
-								onclick={() => voteComment(comment.id)}
+								class:voted={getCommentVoteState(comment.id) === 'up'}
+								onclick={() => voteComment(comment.id, 'up')}
 								aria-label="upvote comment"
 							>
 								&#9650;
 							</button>
+							{#if data.user && data.user.karma >= 500}
+								<button
+									class="downvote"
+									class:voted={getCommentVoteState(comment.id) === 'down'}
+									onclick={() => voteComment(comment.id, 'down')}
+									aria-label="downvote comment"
+								>
+									&#9660;
+								</button>
+							{/if}
 						</span>
 						<a href="/user/{comment.username}" style={isNewUser(comment.user_created_at) ? 'color: #3c963c;' : ''}>{comment.username}</a>
 						<a href="/item/{comment.id}">{timeAgo(comment.created_at)}</a>
@@ -491,7 +530,7 @@
 							</form>
 						</div>
 					{:else}
-						<div class="comment-text" style="padding-left: 14px;">
+						<div class="comment-text" class:faded={getCommentPoints(comment) < 1} style="padding-left: 14px;">
 							{#each comment.text.split('\n') as paragraph}
 								{#if paragraph.trim()}
 									<p>{@html formatText(paragraph)}</p>

--- a/src/routes/item/[id]/+page.svelte
+++ b/src/routes/item/[id]/+page.svelte
@@ -47,16 +47,6 @@
 		localTargetCommentPoints ?? (data.mode === 'comment' ? data.targetComment.points : 0)
 	);
 
-	function canDownvote(commentUserId: number, parentId: number | null): boolean {
-		if (!data.user) return false;
-		if (data.user.karma < 500) return false;
-		// Cannot downvote direct replies to own comments (checked server-side too, but hide button)
-		// We don't have parent author info client-side for all cases, so we show the button
-		// and let the server reject if needed. But for the target comment in comment mode,
-		// we can check.
-		return true;
-	}
-
 	interface CommentNode {
 		id: number;
 		text: string;
@@ -142,11 +132,13 @@
 			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
 			localTargetCommentPoints = result.points;
 			localTargetCommentVoteState = result.voteState;
-			// Also update in the local states
 			localCommentVoteStates = {
 				...(localCommentVoteStates ?? {}),
 				[data.targetComment.id]: result.voteState
 			};
+		} else if (res.status === 403) {
+			const result = await res.json();
+			alert(result.error || 'Permission denied');
 		}
 	}
 
@@ -167,6 +159,9 @@
 				...(localCommentVoteStates ?? {}),
 				[commentId]: result.voteState
 			};
+		} else if (res.status === 403) {
+			const result = await res.json();
+			alert(result.error || 'Permission denied');
 		}
 	}
 

--- a/src/routes/lists/+page.svelte
+++ b/src/routes/lists/+page.svelte
@@ -1,5 +1,5 @@
 <div class="lists-page">
-	<table>
+	<table><tbody>
 		<tr>
 			<td><a href="/front">front</a></td>
 			<td>past stories</td>
@@ -24,7 +24,7 @@
 			<td><a href="/ask">ask</a></td>
 			<td>Ask HN</td>
 		</tr>
-	</table>
+	</tbody></table>
 </div>
 
 <style>

--- a/src/routes/newcomments/+page.server.ts
+++ b/src/routes/newcomments/+page.server.ts
@@ -1,5 +1,5 @@
 import type { PageServerLoad } from './$types';
-import { getDB, getRecentComments, getVotedCommentIds } from '$lib/server/db';
+import { getDB, getRecentComments, getCommentVoteStates } from '$lib/server/db';
 
 export const load: PageServerLoad = async ({ url, platform, locals }) => {
 	const db = getDB(platform);
@@ -7,9 +7,9 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 
 	const comments = await getRecentComments(db, page, 30);
 
-	let votedIds: Set<number> = new Set();
+	let commentVoteStates: Map<number, 'up' | 'down'> = new Map();
 	if (locals.user) {
-		votedIds = await getVotedCommentIds(
+		commentVoteStates = await getCommentVoteStates(
 			db,
 			locals.user.id,
 			comments.map((c: any) => c.id)
@@ -18,7 +18,7 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 
 	return {
 		comments,
-		votedIds: Array.from(votedIds),
+		commentVoteStates: Object.fromEntries(commentVoteStates),
 		page
 	};
 };

--- a/src/routes/newcomments/+page.svelte
+++ b/src/routes/newcomments/+page.svelte
@@ -3,18 +3,21 @@
 	import { formatText } from '$lib/format';
 
 	let { data } = $props();
-	let localVotedIds = $state<Set<number> | null>(null);
+	let localVoteStates = $state<Record<number, 'up' | 'down' | null> | null>(null);
 	let localPoints = $state<Record<number, number>>({});
 
-	function getVotedIds(): Set<number> {
-		return localVotedIds ?? new Set(data.votedIds);
+	function getVoteState(commentId: number): 'up' | 'down' | null {
+		if (localVoteStates && commentId in localVoteStates) {
+			return localVoteStates[commentId];
+		}
+		return (data.commentVoteStates as Record<number, 'up' | 'down'>)[commentId] ?? null;
 	}
 
 	function getPoints(comment: { id: number; points: number }): number {
 		return localPoints[comment.id] ?? comment.points;
 	}
 
-	async function vote(commentId: number) {
+	async function vote(commentId: number, direction: 'up' | 'down' = 'up') {
 		if (!data.user) {
 			window.location.href = '/login';
 			return;
@@ -22,18 +25,15 @@
 		const res = await fetch('/api/vote', {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ itemId: commentId, itemType: 'comment' })
+			body: JSON.stringify({ itemId: commentId, itemType: 'comment', direction })
 		});
 		if (res.ok) {
-			const result: { voted: boolean; points: number } = await res.json();
+			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
 			localPoints = { ...localPoints, [commentId]: result.points };
-			const next = new Set(getVotedIds());
-			if (result.voted) {
-				next.add(commentId);
-			} else {
-				next.delete(commentId);
-			}
-			localVotedIds = next;
+			localVoteStates = {
+				...(localVoteStates ?? {}),
+				[commentId]: result.voteState
+			};
 		}
 	}
 </script>
@@ -49,12 +49,22 @@
 				<span class="comment-vote">
 					<button
 						class="upvote"
-						class:voted={getVotedIds().has(comment.id)}
-						onclick={() => vote(comment.id)}
+						class:voted={getVoteState(comment.id) === 'up'}
+						onclick={() => vote(comment.id, 'up')}
 						aria-label="upvote comment"
 					>
 						&#9650;
 					</button>
+					{#if data.user && data.user.karma >= 500}
+						<button
+							class="downvote"
+							class:voted={getVoteState(comment.id) === 'down'}
+							onclick={() => vote(comment.id, 'down')}
+							aria-label="downvote comment"
+						>
+							&#9660;
+						</button>
+					{/if}
 				</span>
 				<a href="/user/{comment.username}" style={isNewUser(comment.user_created_at) ? 'color: #3c963c;' : ''}>{comment.username}</a>
 				<a href="/item/{comment.id}">{timeAgo(comment.created_at)}</a>
@@ -62,7 +72,7 @@
 				| <a href="/item/{comment.id}" style="color: #828282;">context</a>
 				| on: <a href="/item/{comment.story_id}">{comment.story_title}</a>
 			</div>
-			<div class="comment-text" style="padding-left: 14px;">
+			<div class="comment-text" class:faded={getPoints(comment) < 1} style="padding-left: 14px;">
 				{#each comment.text.split('\n') as paragraph}
 					{#if paragraph.trim()}
 						<p>{@html formatText(paragraph)}</p>

--- a/src/routes/newcomments/+page.svelte
+++ b/src/routes/newcomments/+page.svelte
@@ -34,6 +34,9 @@
 				...(localVoteStates ?? {}),
 				[commentId]: result.voteState
 			};
+		} else if (res.status === 403) {
+			const result = await res.json();
+			alert(result.error || 'Permission denied');
 		}
 	}
 </script>

--- a/src/routes/newest/+page.svelte
+++ b/src/routes/newest/+page.svelte
@@ -46,10 +46,10 @@
 			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
 		});
 		if (res.ok) {
-			const result: { voted: boolean; points: number } = await res.json();
+			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
 			localPoints = { ...localPoints, [storyId]: result.points };
 			const next = new Set(getVotedIds());
-			if (result.voted) {
+			if (result.voteState === 'up') {
 				next.add(storyId);
 			} else {
 				next.delete(storyId);

--- a/src/routes/show/+page.svelte
+++ b/src/routes/show/+page.svelte
@@ -46,10 +46,10 @@
 			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
 		});
 		if (res.ok) {
-			const result: { voted: boolean; points: number } = await res.json();
+			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
 			localPoints = { ...localPoints, [storyId]: result.points };
 			const next = new Set(getVotedIds());
-			if (result.voted) {
+			if (result.voteState === 'up') {
 				next.add(storyId);
 			} else {
 				next.delete(storyId);

--- a/src/routes/user/[id]/comments/+page.server.ts
+++ b/src/routes/user/[id]/comments/+page.server.ts
@@ -1,5 +1,5 @@
 import type { PageServerLoad } from './$types';
-import { getDB, getUserByUsername, getCommentsByUserId, getVotedCommentIds } from '$lib/server/db';
+import { getDB, getUserByUsername, getCommentsByUserId, getCommentVoteStates } from '$lib/server/db';
 import { error } from '@sveltejs/kit';
 
 export const load: PageServerLoad = async ({ params, url, platform, locals }) => {
@@ -14,9 +14,9 @@ export const load: PageServerLoad = async ({ params, url, platform, locals }) =>
 
 	const comments = await getCommentsByUserId(db, user.id, page, 30);
 
-	let votedIds: Set<number> = new Set();
+	let commentVoteStates: Map<number, 'up' | 'down'> = new Map();
 	if (locals.user) {
-		votedIds = await getVotedCommentIds(
+		commentVoteStates = await getCommentVoteStates(
 			db,
 			locals.user.id,
 			comments.map((c: any) => c.id)
@@ -26,7 +26,7 @@ export const load: PageServerLoad = async ({ params, url, platform, locals }) =>
 	return {
 		username: user.username,
 		comments,
-		votedIds: Array.from(votedIds),
+		commentVoteStates: Object.fromEntries(commentVoteStates),
 		page
 	};
 };

--- a/src/routes/user/[id]/comments/+page.svelte
+++ b/src/routes/user/[id]/comments/+page.svelte
@@ -3,18 +3,21 @@
 	import { formatText } from '$lib/format';
 
 	let { data } = $props();
-	let localVotedIds = $state<Set<number> | null>(null);
+	let localVoteStates = $state<Record<number, 'up' | 'down' | null> | null>(null);
 	let localPoints = $state<Record<number, number>>({});
 
-	function getVotedIds(): Set<number> {
-		return localVotedIds ?? new Set(data.votedIds);
+	function getVoteState(commentId: number): 'up' | 'down' | null {
+		if (localVoteStates && commentId in localVoteStates) {
+			return localVoteStates[commentId];
+		}
+		return (data.commentVoteStates as Record<number, 'up' | 'down'>)[commentId] ?? null;
 	}
 
 	function getPoints(comment: { id: number; points: number }): number {
 		return localPoints[comment.id] ?? comment.points;
 	}
 
-	async function vote(commentId: number) {
+	async function vote(commentId: number, direction: 'up' | 'down' = 'up') {
 		if (!data.user) {
 			window.location.href = '/login';
 			return;
@@ -22,18 +25,15 @@
 		const res = await fetch('/api/vote', {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ itemId: commentId, itemType: 'comment' })
+			body: JSON.stringify({ itemId: commentId, itemType: 'comment', direction })
 		});
 		if (res.ok) {
-			const result: { voted: boolean; points: number } = await res.json();
+			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
 			localPoints = { ...localPoints, [commentId]: result.points };
-			const next = new Set(getVotedIds());
-			if (result.voted) {
-				next.add(commentId);
-			} else {
-				next.delete(commentId);
-			}
-			localVotedIds = next;
+			localVoteStates = {
+				...(localVoteStates ?? {}),
+				[commentId]: result.voteState
+			};
 		}
 	}
 </script>
@@ -49,12 +49,22 @@
 				<span class="comment-vote">
 					<button
 						class="upvote"
-						class:voted={getVotedIds().has(comment.id)}
-						onclick={() => vote(comment.id)}
+						class:voted={getVoteState(comment.id) === 'up'}
+						onclick={() => vote(comment.id, 'up')}
 						aria-label="upvote comment"
 					>
 						&#9650;
 					</button>
+					{#if data.user && data.user.karma >= 500}
+						<button
+							class="downvote"
+							class:voted={getVoteState(comment.id) === 'down'}
+							onclick={() => vote(comment.id, 'down')}
+							aria-label="downvote comment"
+						>
+							&#9660;
+						</button>
+					{/if}
 				</span>
 				<a href="/user/{comment.username}" style={isNewUser(comment.user_created_at) ? 'color: #3c963c;' : ''}>{comment.username}</a>
 				<a href="/item/{comment.id}">{timeAgo(comment.created_at)}</a>
@@ -62,7 +72,7 @@
 				| <a href="/item/{comment.id}" style="color: #828282;">context</a>
 				| on: <a href="/item/{comment.story_id}">{comment.story_title}</a>
 			</div>
-			<div class="comment-text" style="padding-left: 14px;">
+			<div class="comment-text" class:faded={getPoints(comment) < 1} style="padding-left: 14px;">
 				{#each comment.text.split('\n') as paragraph}
 					{#if paragraph.trim()}
 						<p>{@html formatText(paragraph)}</p>

--- a/src/routes/user/[id]/comments/+page.svelte
+++ b/src/routes/user/[id]/comments/+page.svelte
@@ -34,6 +34,9 @@
 				...(localVoteStates ?? {}),
 				[commentId]: result.voteState
 			};
+		} else if (res.status === 403) {
+			const result = await res.json();
+			alert(result.error || 'Permission denied');
 		}
 	}
 </script>

--- a/src/routes/user/[id]/favorites/+page.svelte
+++ b/src/routes/user/[id]/favorites/+page.svelte
@@ -25,10 +25,10 @@
 			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
 		});
 		if (res.ok) {
-			const result: { voted: boolean; points: number } = await res.json();
+			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
 			localPoints = { ...localPoints, [storyId]: result.points };
 			const next = new Set(getVotedIds());
-			if (result.voted) {
+			if (result.voteState === 'up') {
 				next.add(storyId);
 			} else {
 				next.delete(storyId);

--- a/src/routes/user/[id]/hidden/+page.svelte
+++ b/src/routes/user/[id]/hidden/+page.svelte
@@ -46,10 +46,10 @@
 			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
 		});
 		if (res.ok) {
-			const result: { voted: boolean; points: number } = await res.json();
+			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
 			localPoints = { ...localPoints, [storyId]: result.points };
 			const next = new Set(getVotedIds());
-			if (result.voted) {
+			if (result.voteState === 'up') {
 				next.add(storyId);
 			} else {
 				next.delete(storyId);

--- a/src/routes/user/[id]/submissions/+page.svelte
+++ b/src/routes/user/[id]/submissions/+page.svelte
@@ -25,10 +25,10 @@
 			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
 		});
 		if (res.ok) {
-			const result: { voted: boolean; points: number } = await res.json();
+			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
 			localPoints = { ...localPoints, [storyId]: result.points };
 			const next = new Set(getVotedIds());
-			if (result.voted) {
+			if (result.voteState === 'up') {
 				next.add(storyId);
 			} else {
 				next.delete(storyId);


### PR DESCRIPTION
## 関連 Issue
closes #20

## 変更内容
- DBスキーマ: votesテーブルにvote_typeカラム追加（'up'/'down'）
- API: /api/vote にdirectionパラメータ追加、karma >= 500制限、直接返信downvote不可、トグル/切替ロジック
- db.ts: hasVoted→getVoteState、getVotedCommentIds→getCommentVoteStates に変更
- UI: コメント3箇所（item/[id], newcomments, user/[id]/comments）に▼ボタン追加
- points < 1 のコメントテキストをフェード表示
- ストーリー一覧10ページのAPIレスポンス形状対応
- docs: spec.md, architecture.md 更新
- fix: lists/+page.svelteの既存ビルドエラー修正（tbody追加）

## デプロイ時の手順
既存DBに対して以下を実行:
```sql
ALTER TABLE votes ADD COLUMN vote_type TEXT NOT NULL DEFAULT 'up' CHECK (vote_type IN ('up', 'down'));
```