### PR TITLE
feat: #62 投稿・コメントの削除機能を追加

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -118,6 +118,15 @@ score = (points - 1) / (hours_since_post + 2) ^ 1.8
 - コメント: 投稿から2時間以内、本人のみ text を編集可能
 - ストーリー編集時は type を再判定（Ask HN: / Show HN: プレフィックス）
 
+### 削除機能
+
+- 投稿・コメントから 2 時間以内、本人のみ削除可能（編集ウィンドウと同条件）
+- 物理削除ではなく **論理削除**: テキストを `[deleted]` に置換するのみ
+  - 投稿: `title`、`url`、`text` を `[deleted]` に置換（url は NULL）
+  - コメント: `text` を `[deleted]` に置換
+- `[deleted]` は `dead`（モデレーション）とは別概念。`showdead` 設定の影響を受けず、常に `[deleted]` のまま表示される
+- フロントエンドでは確認ダイアログ（`confirm()`）を挟む
+
 ### 静的ページ
 
 - `/guidelines` — 投稿・コメントのガイドライン
@@ -135,6 +144,7 @@ score = (points - 1) / (hours_since_post + 2) ^ 1.8
 - [x] ページネーション
 - [x] プロフィール編集
 - [x] 投稿・コメント編集（2時間以内）
+- [x] 投稿・コメント削除（2時間以内、`[deleted]` 置換）
 - [x] ガイドライン・FAQ・Show HN ルールページ
 - [x] ユーザーの submissions / comments 一覧ページ
 - [x] コメントパーマリンク（/item/{comment_id}）

--- a/src/app.css
+++ b/src/app.css
@@ -406,6 +406,22 @@ a:hover {
 	text-decoration: underline;
 }
 
+/* フォームボタンを a タグと同じ見た目にするためのユーティリティ（delete などの POST リンク用） */
+.link-button {
+	background: none;
+	border: none;
+	padding: 0;
+	margin: 0;
+	font: inherit;
+	color: inherit;
+	cursor: pointer;
+	text-decoration: underline;
+}
+
+.link-button:hover {
+	color: inherit;
+}
+
 /* User page */
 .user-profile {
 	padding: 10px 0;

--- a/src/app.css
+++ b/src/app.css
@@ -418,8 +418,9 @@ a:hover {
 	text-decoration: underline;
 }
 
-.link-button:hover {
-	color: inherit;
+/* インライン配置用 form（edit/delete を同じ行に並べる） */
+.inline-form {
+	display: inline;
 }
 
 /* User page */

--- a/src/routes/item/[id]/+page.server.ts
+++ b/src/routes/item/[id]/+page.server.ts
@@ -215,5 +215,66 @@ export const actions: Actions = {
 			.run();
 
 		return { success: true };
+	},
+
+	deleteStory: async ({ platform, locals, params }) => {
+		if (!locals.user) {
+			throw redirect(302, '/login');
+		}
+
+		const db = getDB(platform);
+		const storyId = parseInt(params.id, 10);
+		const story = await getStoryById(db, storyId);
+
+		if (!story) {
+			throw error(404, 'Story not found');
+		}
+
+		if (story.user_id !== locals.user.id) {
+			throw error(403, "Cannot delete another user's story");
+		}
+
+		const elapsed = Date.now() - new Date(story.created_at).getTime();
+		if (elapsed >= 2 * 60 * 60 * 1000) {
+			return fail(400, { error: 'Delete window has expired (2 hours)' });
+		}
+
+		await db
+			.prepare('UPDATE stories SET title = ?, url = ?, text = ? WHERE id = ?')
+			.bind('[deleted]', null, '[deleted]', storyId)
+			.run();
+
+		return { success: true };
+	},
+
+	deleteComment: async ({ request, platform, locals }) => {
+		if (!locals.user) {
+			throw redirect(302, '/login');
+		}
+
+		const db = getDB(platform);
+		const formData = await request.formData();
+		const commentId = parseInt(formData.get('comment_id') as string, 10);
+
+		const comment = await getCommentById(db, commentId);
+		if (!comment) {
+			throw error(404, 'Comment not found');
+		}
+
+		if (comment.user_id !== locals.user.id) {
+			throw error(403, "Cannot delete another user's comment");
+		}
+
+		const elapsed = Date.now() - new Date(comment.created_at).getTime();
+		if (elapsed >= 2 * 60 * 60 * 1000) {
+			return fail(400, { error: 'Delete window has expired (2 hours)' });
+		}
+
+		await db
+			.prepare('UPDATE comments SET text = ? WHERE id = ?')
+			.bind('[deleted]', commentId)
+			.run();
+
+		return { success: true };
 	}
 };

--- a/src/routes/item/[id]/+page.server.ts
+++ b/src/routes/item/[id]/+page.server.ts
@@ -236,7 +236,12 @@ export const actions: Actions = {
 
 		const elapsed = Date.now() - new Date(story.created_at).getTime();
 		if (elapsed >= 2 * 60 * 60 * 1000) {
-			return fail(400, { error: 'Delete window has expired (2 hours)' });
+			return fail(400, { error: 'Cannot delete after 2 hours' });
+		}
+
+		// 既に削除済みなら DB 書き込みをスキップ（冪等）
+		if (story.title === '[deleted]') {
+			return { success: true };
 		}
 
 		await db
@@ -267,7 +272,12 @@ export const actions: Actions = {
 
 		const elapsed = Date.now() - new Date(comment.created_at).getTime();
 		if (elapsed >= 2 * 60 * 60 * 1000) {
-			return fail(400, { error: 'Delete window has expired (2 hours)' });
+			return fail(400, { error: 'Cannot delete after 2 hours' });
+		}
+
+		// 既に削除済みなら DB 書き込みをスキップ（冪等）
+		if (comment.text === '[deleted]') {
+			return { success: true };
 		}
 
 		await db

--- a/src/routes/item/[id]/+page.svelte
+++ b/src/routes/item/[id]/+page.svelte
@@ -22,6 +22,17 @@
 		return elapsed < 2 * 60 * 60 * 1000;
 	}
 
+	const confirmDelete = (message: string) => ({ cancel }: { cancel: () => void }) => {
+		if (!confirm(message)) {
+			cancel();
+			return;
+		}
+		return async ({ update }: { update: () => Promise<void> }) => {
+			await update();
+			await invalidateAll();
+		};
+	};
+
 	let storyVoted = $derived(localStoryVoted ?? (data.mode === 'story' ? data.storyVoted : false));
 	let storyPoints = $derived(localStoryPoints ?? (data.mode === 'story' ? data.story.points : 0));
 	let storyFavorited = $derived(localStoryFavorited ?? (data.mode === 'story' ? data.storyFavorited : false));
@@ -356,16 +367,7 @@
 										e.preventDefault();
 										editingCommentId = child.id;
 									}}>edit</a>
-								| <form method="POST" action="?/deleteComment" style="display: inline;" use:enhance={({ cancel }) => {
-									if (!confirm('Delete this comment? Text will be replaced with [deleted].')) {
-										cancel();
-										return;
-									}
-									return async ({ update }) => {
-										await update();
-										await invalidateAll();
-									};
-								}}>
+								| <form method="POST" action="?/deleteComment" class="inline-form" use:enhance={confirmDelete('Delete this comment? Text will be replaced with [deleted].')}>
 									<input type="hidden" name="comment_id" value={child.id} />
 									<button type="submit" class="link-button">delete</button>
 								</form>
@@ -426,16 +428,7 @@
 						e.preventDefault();
 						editingStory = true;
 					}}>edit</a>
-				| <form method="POST" action="?/deleteStory" style="display: inline;" use:enhance={({ cancel }) => {
-					if (!confirm('Delete this story? Text will be replaced with [deleted].')) {
-						cancel();
-						return;
-					}
-					return async ({ update }) => {
-						await update();
-						await invalidateAll();
-					};
-				}}>
+				| <form method="POST" action="?/deleteStory" class="inline-form" use:enhance={confirmDelete('Delete this story? Text will be replaced with [deleted].')}>
 					<button type="submit" class="link-button">delete</button>
 				</form>
 			{/if}
@@ -584,16 +577,7 @@
 										e.preventDefault();
 										editingCommentId = comment.id;
 									}}>edit</a>
-								| <form method="POST" action="?/deleteComment" style="display: inline;" use:enhance={({ cancel }) => {
-									if (!confirm('Delete this comment? Text will be replaced with [deleted].')) {
-										cancel();
-										return;
-									}
-									return async ({ update }) => {
-										await update();
-										await invalidateAll();
-									};
-								}}>
+								| <form method="POST" action="?/deleteComment" class="inline-form" use:enhance={confirmDelete('Delete this comment? Text will be replaced with [deleted].')}>
 									<input type="hidden" name="comment_id" value={comment.id} />
 									<button type="submit" class="link-button">delete</button>
 								</form>

--- a/src/routes/item/[id]/+page.svelte
+++ b/src/routes/item/[id]/+page.svelte
@@ -356,6 +356,19 @@
 										e.preventDefault();
 										editingCommentId = child.id;
 									}}>edit</a>
+								| <form method="POST" action="?/deleteComment" style="display: inline;" use:enhance={({ cancel }) => {
+									if (!confirm('Delete this comment? Text will be replaced with [deleted].')) {
+										cancel();
+										return;
+									}
+									return async ({ update }) => {
+										await update();
+										await invalidateAll();
+									};
+								}}>
+									<input type="hidden" name="comment_id" value={child.id} />
+									<button type="submit" class="link-button">delete</button>
+								</form>
 							{/if}
 						</div>
 						{#if isThreadOpen(data.parentStory.created_at) && replyTo === child.id}
@@ -413,6 +426,18 @@
 						e.preventDefault();
 						editingStory = true;
 					}}>edit</a>
+				| <form method="POST" action="?/deleteStory" style="display: inline;" use:enhance={({ cancel }) => {
+					if (!confirm('Delete this story? Text will be replaced with [deleted].')) {
+						cancel();
+						return;
+					}
+					return async ({ update }) => {
+						await update();
+						await invalidateAll();
+					};
+				}}>
+					<button type="submit" class="link-button">delete</button>
+				</form>
 			{/if}
 			{#if data.user}
 				| <a
@@ -559,6 +584,19 @@
 										e.preventDefault();
 										editingCommentId = comment.id;
 									}}>edit</a>
+								| <form method="POST" action="?/deleteComment" style="display: inline;" use:enhance={({ cancel }) => {
+									if (!confirm('Delete this comment? Text will be replaced with [deleted].')) {
+										cancel();
+										return;
+									}
+									return async ({ update }) => {
+										await update();
+										await invalidateAll();
+									};
+								}}>
+									<input type="hidden" name="comment_id" value={comment.id} />
+									<button type="submit" class="link-button">delete</button>
+								</form>
 							{/if}
 						</div>
 						{#if isThreadOpen(data.story.created_at) && replyTo === comment.id}


### PR DESCRIPTION
## 関連 Issue

closes #62

## 仕様

本家 HN 同様、本人のみが投稿/コメントを 2 時間以内に削除可能にする。**編集機能と完全に同条件**。

- 物理削除ではなく論理削除（テキストを `[deleted]` に置換）
- `[deleted]` は `dead`（モデレーション）と別概念。`showdead` 設定の影響を受けない
- フロントエンドでは `confirm()` で確認ダイアログを挟む（誤クリック防止）

## 変更

| ファイル | 内容 |
|---|---|
| `src/routes/item/[id]/+page.server.ts` | `deleteStory` / `deleteComment` アクションを追加。既存 edit と同じオーナー + 2h チェック |
| `src/routes/item/[id]/+page.svelte` | 3 箇所（投稿ヘッダ / 子コメント / トップレベルコメント）に delete リンク追加 |
| `src/app.css` | `.link-button` ユーティリティを追加（form の POST ボタンを a タグ風に） |
| `docs/spec.md` | 「削除機能」セクションを追加、v1 スコープに項目追加 |

## DB

- 投稿: `title='[deleted]', url=NULL, text='[deleted]'`
- コメント: `text='[deleted]'`
- スキーマ変更なし（既存カラムのみ使用）

## 検証

- `npm run check`: 既存の 10 エラー（pre-existing、本 PR で増減なし）
- `npm run build`: 成功
- 確認ダイアログ → POST → 該当行のテキスト置換まで実装完了

## スコープ外

`dead` 列を必要とするモデレーション周りは Issue #17 / #63 の範囲なので本 PR では触らない。