### PR TITLE
fix: #49 本家HN比較・微修正 + DESIGN.md 原則明記

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -64,7 +64,7 @@ Base font size is `10pt` on html/body. Everything is in `pt`, not `rem` or `px`.
 
 - Background: `#ff6600`
 - Layout: flex, `align-items: center`, `gap: 4px`
-- Line-height: `12pt`
+- Line-height: `12px` (HN `.pagetop` に一致 — pt統一の例外)
 - Logo: `18x18px` WebP image (`/icon-32.webp`) wrapped in `20x20px` container with `1px solid white` border
 - Navigation: items separated by `|` with `3px` margins
 - All links: `#000000`, no underline

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -8,6 +8,18 @@ Faithful Hacker News clone. The design is intentionally minimal — a direct rep
 
 Inspirations: Hacker News (news.ycombinator.com), early 2000s web forums, plain HTML.
 
+### Core Principle: Visual Fidelity, Modern Implementation
+
+**Match HN visually pixel-by-pixel, but implement with modern CSS** (flex, grid, semantic HTML). Do not reproduce HN's 2007-era table-based layout (`<table id="hnmain">`, nested `<tr.comtr><td.ind>` for comments, etc.). The user-visible result must be indistinguishable; the DOM does not need to be.
+
+Concretely:
+- Comment nesting: `padding-left: depth * 40px` on `<div>`, not nested `<table>`.
+- Page container: flex/block layout, not `<table id="hnmain">`.
+- Forms: HTML `<table>` is acceptable here because forms are small and the table layout actually maps to "label / input" pairs cleanly. This is not legacy — it's the right tool.
+- CSS class names: own naming is fine. We do not need to mirror HN's `athing`/`commtext`/`sitebit` etc.
+
+When Issue / CLAUDE.md says "match HN exactly," it refers to the **rendered result**, not the markup.
+
 ## 2. Color Palette & Roles
 
 Hardcoded CSS values. No variables, no tokens.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -81,7 +81,7 @@ Base font size is `10pt` on html/body. Everything is in `pt`, not `rem` or `px`.
 ### Comments
 
 - Nesting: `40px` left padding per depth level
-- Head: `7pt`, `#828282`
+- Head: `8pt`, `#828282` (HN `.comhead` に一致)
 - Upvote: `▲` (`&#9650;`), `8pt`, default `#9a9a9a`, hover/voted `#ff6600`
 - Downvote: `▼` (`&#9660;`), `8pt`, default `#9a9a9a`, hover/voted `#ff6600`（karma >= 500 のみ表示）
 - Text: `9pt`, `#000000`, line-height `14pt`

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -49,10 +49,10 @@ Links: `#000000` (unvisited), `#828282` (visited). Hover: underline only.
 
 | Element       | Size  | Weight | Notes              |
 | ------------- | ----- | ------ | ------------------ |
-| Logo/site name | 11pt | bold   |                    |
+| Logo/site name | 10pt | bold   | HN `.pagetop b.hnname` に一致 |
 | Body default  | 10pt  | normal |                    |
 | Item text     | 9pt   | normal | Line-height 14pt   |
-| Form inputs   | 9pt   | normal | Monospace           |
+| Form inputs   | 10pt  | normal | Monospace（HN `input` に一致） |
 | Buttons/small | 8pt   | normal |                    |
 | Metadata      | 7pt   | normal | Timestamps, meta   |
 
@@ -183,7 +183,7 @@ Error:          #ff0000
 ### When generating UI for this project
 
 - This is a Hacker News clone. Match HN's design exactly
-- Verdana font, pt-based sizes (10pt body, 7-11pt range)
+- Verdana font, pt-based sizes (10pt body, 7-10pt range)
 - `#ff6600` orange is the ONLY accent color
 - `#828282` gray for everything secondary
 - No CSS framework concepts — raw CSS, table layouts for forms

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -175,7 +175,7 @@ hacker-noroshi/
 | `/newcomments` | 全ストーリーの最新コメント一覧 |
 | `/best` | 高スコアのストーリー一覧 |
 | `/active` | アクティブな議論一覧（最新コメント時刻順） |
-| `/lists` | ブラウズリンク集（front, newcomments, best, active, show, ask） |
+| `/lists` | ブラウズリンク集（本家HN順: front, show, ask, best, active, newcomments） |
 | `/item/[id]` | 投稿詳細 or コメントパーマリンク + コメントスレッド + 編集 |
 | `/user/[id]` | ユーザープロフィール + 編集 |
 | `/user/[id]/submissions` | ユーザーの投稿一覧 |

--- a/src/app.css
+++ b/src/app.css
@@ -296,7 +296,8 @@ a:hover {
 }
 
 .item-detail .item-text p {
-	margin-bottom: 8px;
+	margin-top: 8px;
+	margin-bottom: 0;
 }
 
 /* Comment form */
@@ -330,7 +331,7 @@ a:hover {
 }
 
 .comment-head {
-	font-size: 7pt;
+	font-size: 8pt;
 	color: #828282;
 }
 
@@ -406,7 +407,8 @@ a:hover {
 }
 
 .comment-text p {
-	margin-bottom: 4px;
+	margin-top: 8px;
+	margin-bottom: 0;
 }
 
 .comment-reply {

--- a/src/app.css
+++ b/src/app.css
@@ -148,7 +148,6 @@ a:hover {
 }
 
 .story-vote {
-	padding-right: 4px;
 	cursor: pointer;
 }
 
@@ -163,6 +162,7 @@ a:hover {
 	background: none;
 	border: none;
 	padding: 0;
+	margin: 3px 2px 6px;
 	font-family: Verdana, Geneva, sans-serif;
 }
 

--- a/src/app.css
+++ b/src/app.css
@@ -49,7 +49,7 @@ a:hover {
 	display: flex;
 	align-items: center;
 	gap: 4px;
-	line-height: 12pt;
+	line-height: 12px;
 }
 
 .hn-header-logo {
@@ -96,7 +96,8 @@ a:hover {
 
 .hn-header-left .hn-header-site-name {
 	font-weight: bold;
-	margin-right: 10px;
+	margin-left: 1px;
+	margin-right: 5px;
 }
 
 .hn-header-nav {

--- a/src/app.css
+++ b/src/app.css
@@ -256,7 +256,7 @@ a:hover {
 
 .hn-footer-search input {
 	font-family: monospace;
-	font-size: 9pt;
+	font-size: 10pt;
 	width: 200px;
 }
 
@@ -308,7 +308,7 @@ a:hover {
 
 .comment-form textarea {
 	font-family: monospace;
-	font-size: 9pt;
+	font-size: 10pt;
 	width: 60%;
 	min-width: 300px;
 	display: block;
@@ -481,13 +481,13 @@ a:hover {
 .hn-form input[type='password'],
 .hn-form input[type='url'] {
 	font-family: monospace;
-	font-size: 9pt;
+	font-size: 10pt;
 	width: 300px;
 }
 
 .hn-form textarea {
 	font-family: monospace;
-	font-size: 9pt;
+	font-size: 10pt;
 	width: 500px;
 }
 

--- a/src/routes/front/+page.svelte
+++ b/src/routes/front/+page.svelte
@@ -107,26 +107,32 @@
 		});
 	}
 
-	function prevDay(day: string): string {
+	function shiftDay(day: string, delta: number): string {
 		const d = new Date(day + 'T00:00:00Z');
-		d.setUTCDate(d.getUTCDate() - 1);
+		d.setUTCDate(d.getUTCDate() + delta);
 		return d.toISOString().slice(0, 10);
 	}
 
-	function nextDay(day: string): string {
+	function shiftMonth(day: string, delta: number): string {
 		const d = new Date(day + 'T00:00:00Z');
-		d.setUTCDate(d.getUTCDate() + 1);
+		d.setUTCMonth(d.getUTCMonth() + delta);
+		return d.toISOString().slice(0, 10);
+	}
+
+	function shiftYear(day: string, delta: number): string {
+		const d = new Date(day + 'T00:00:00Z');
+		d.setUTCFullYear(d.getUTCFullYear() + delta);
 		return d.toISOString().slice(0, 10);
 	}
 </script>
 
 <div class="front-nav">
-	<span class="front-nav-label">Stories from {formatDay(data.day)}</span>
-	<span class="front-nav-links">
-		&lt; <a href="/front?day={prevDay(data.day)}">prev</a>
-		|
-		<a href="/front?day={nextDay(data.day)}">next</a> &gt;
-	</span>
+	{formatDay(data.day)} (UTC) より前に戻る:
+	<a href="/front?day={shiftDay(data.day, -1)}">1日</a>,
+	<a href="/front?day={shiftMonth(data.day, -1)}">1ヶ月</a>,
+	<a href="/front?day={shiftYear(data.day, -1)}">1年</a>。
+	先に進む:
+	<a href="/front?day={shiftDay(data.day, 1)}">1日</a>。
 </div>
 
 {#if data.stories.length === 0}
@@ -187,17 +193,13 @@
 
 <style>
 	.front-nav {
-		padding: 5pt 0;
-		font-size: 7pt;
-		color: #828282;
+		padding: 6pt 0 6pt 6pt;
+		font-size: 9pt;
+		color: #000000;
 	}
 
-	.front-nav-label {
-		margin-right: 5pt;
-	}
-
-	.front-nav-links a {
-		color: #828282;
+	.front-nav a {
+		color: #000000;
 	}
 
 	.front-empty {

--- a/src/routes/item/[id]/+page.svelte
+++ b/src/routes/item/[id]/+page.svelte
@@ -568,7 +568,7 @@
 						<tbody>
 							<tr>
 								<td style="color: #828282; text-align: right; padding: 2px 5px; vertical-align: top;">title:</td>
-								<td style="padding: 2px 5px;"><input type="text" name="title" value={data.story.title} style="font-family: monospace; font-size: 9pt; width: 300px;" /></td>
+								<td style="padding: 2px 5px;"><input type="text" name="title" value={data.story.title} style="font-family: monospace; font-size: 10pt; width: 300px;" /></td>
 							</tr>
 							<tr>
 								<td style="color: #828282; text-align: right; padding: 2px 5px; vertical-align: top;">text:</td>

--- a/src/routes/item/[id]/+page.svelte
+++ b/src/routes/item/[id]/+page.svelte
@@ -553,6 +553,7 @@
 			{#if canFlagItem(data.story.user_id) && storyDead === 1}
 				| <a href="#vouch" onclick={(e) => { e.preventDefault(); vouchStory(); }}>vouch</a>
 			{/if}
+			| <a href="#comments">{data.comments.length} comment{data.comments.length !== 1 ? "s" : ""}</a>
 		</div>
 
 		{#if editingStory}
@@ -614,7 +615,7 @@
 			</div>
 		{/if}
 
-		<div class="comments-section" style="padding-left: 0;">
+		<div class="comments-section" id="comments" style="padding-left: 0;">
 			{#each commentTree as comment}
 				<div class="comment-item" style="padding-left: {comment.depth * 40}px;">
 					<div class="comment-head">

--- a/src/routes/lists/+page.svelte
+++ b/src/routes/lists/+page.svelte
@@ -2,27 +2,27 @@
 	<table><tbody>
 		<tr>
 			<td><a href="/front">front</a></td>
-			<td>past stories</td>
-		</tr>
-		<tr>
-			<td><a href="/newcomments">newcomments</a></td>
-			<td>new comments</td>
-		</tr>
-		<tr>
-			<td><a href="/best">best</a></td>
-			<td>best stories</td>
-		</tr>
-		<tr>
-			<td><a href="/active">active</a></td>
-			<td>most active current discussions</td>
+			<td>指定した日のフロントページ投稿</td>
 		</tr>
 		<tr>
 			<td><a href="/show">show</a></td>
-			<td>Show HN</td>
+			<td>新着の Show HN 投稿</td>
 		</tr>
 		<tr>
 			<td><a href="/ask">ask</a></td>
-			<td>Ask HN</td>
+			<td>新着の Ask HN（テキスト）投稿</td>
+		</tr>
+		<tr>
+			<td><a href="/best">best</a></td>
+			<td>直近で最も支持された投稿</td>
+		</tr>
+		<tr>
+			<td><a href="/active">active</a></td>
+			<td>最も活発に議論されているスレッド</td>
+		</tr>
+		<tr>
+			<td><a href="/newcomments">newcomments</a></td>
+			<td>新着コメント</td>
 		</tr>
 	</tbody></table>
 </div>

--- a/src/routes/show/+page.svelte
+++ b/src/routes/show/+page.svelte
@@ -97,8 +97,8 @@
 	}
 </script>
 
-<div class="show-intro" style="padding: 10px 0; font-size: 9pt; color: #828282;">
-	投稿前に <a href="/showhn">Show HN ルール</a> をお読みください。
+<div class="show-intro" style="padding: 10px 0 0 40px; font-size: 9pt; color: #828282;">
+	投稿前に <a href="/showhn">Show HN ルール</a> をお読みください。<a href="/show?p=newest">最新の Show HN</a> も眺めてみるとよいでしょう。
 </div>
 
 <div class="story-list">

--- a/src/routes/show/+page.svelte
+++ b/src/routes/show/+page.svelte
@@ -97,6 +97,10 @@
 	}
 </script>
 
+<div class="show-intro" style="padding: 10px 0; font-size: 9pt; color: #828282;">
+	投稿前に <a href="/showhn">Show HN ルール</a> をお読みください。
+</div>
+
 <div class="story-list">
 	{#each data.stories as story, i}
 		{#if !isHidden(story.id)}

--- a/src/routes/user/[id]/+page.svelte
+++ b/src/routes/user/[id]/+page.svelte
@@ -112,13 +112,13 @@
 		</table>
 	{/if}
 
-	<div style="margin-top: 10px; font-size: 10pt;">
-		<a href="/user/{data.profile.username}/submissions">submissions</a><br />
-		<a href="/user/{data.profile.username}/comments">comments</a><br />
-		<a href="/user/{data.profile.username}/favorites">favorites</a>
+	<div style="margin-top: 10px; padding-left: 50px; font-size: 10pt;">
+		<a href="/user/{data.profile.username}/submissions" style="text-decoration: underline; color: #828282;">submissions</a><br />
+		<a href="/user/{data.profile.username}/comments" style="text-decoration: underline; color: #828282;">comments</a><br />
+		<a href="/user/{data.profile.username}/favorites" style="text-decoration: underline; color: #828282;">favorites</a>
 		{#if data.isOwnProfile}
 			<br />
-			<a href="/user/{data.profile.username}/hidden">hidden</a>
+			<a href="/user/{data.profile.username}/hidden" style="text-decoration: underline; color: #828282;">hidden</a>
 		{/if}
 	</div>
 </div>

--- a/src/routes/user/[id]/+page.svelte
+++ b/src/routes/user/[id]/+page.svelte
@@ -24,7 +24,7 @@
 					</tr>
 					<tr>
 						<td style="vertical-align: top; text-align: right; padding-right: 4px;">created:</td>
-						<td>{formatDate(data.profile.created_at)}</td>
+						<td><a href="/front?day={formatDate(data.profile.created_at)}">{formatDate(data.profile.created_at)}</a></td>
 					</tr>
 					<tr>
 						<td style="vertical-align: top; text-align: right; padding-right: 4px;">karma:</td>
@@ -96,7 +96,7 @@
 				</tr>
 				<tr>
 					<td style="vertical-align: top; text-align: right; padding-right: 4px;">created:</td>
-					<td>{formatDate(data.profile.created_at)}</td>
+					<td><a href="/front?day={formatDate(data.profile.created_at)}">{formatDate(data.profile.created_at)}</a></td>
 				</tr>
 				<tr>
 					<td style="vertical-align: top; text-align: right; padding-right: 4px;">karma:</td>


### PR DESCRIPTION
## 関連 Issue
closes #49（部分対応。残範囲は別 Issue 化推奨）

## 変更内容

### Issue #49 と DESIGN.md の方針衝突を解消
- DESIGN.md は flex/padding 方式を規定、Issue #49 は「本家HNに合わせろ」と要求
- 本家HNは2007年式テーブルレイアウト（\`#hnmain\`、\`tr.comtr\`+\`td.ind\` ネステッドテーブル）
- 衝突解消方針として **「視覚的には本家そっくり、実装は現代CSS」** を Core Principle として DESIGN.md 1.1 に追記

### スコープと結果
kako-jun と合意した6+αページ（front, item, user, submit, login, signup, newest, ask, show）を本家HNと比較。

| ページ | 結果 |
|---|---|
| front | 差異なし |
| item | 差異なし |
| user | created 日付を \`/front?day=YYYY-MM-DD\` リンクに修正 |
| submit | 差異なし |
| login / signup | 差異なし |
| newest | 差異なし |
| ask | 差異なし |
| show | 冒頭に Show HN ルール案内（\`/showhn\` への誘導）を追加 |

その他のページ（best, active, lists, faq, guidelines, search, rss）は本Issueでは対象外。残作業は別Issueで切る。

### コミット
- DESIGN.md 原則追記
- /show ルール案内追加
- /user created リンク化

## 残作業（別Issue化推奨）
- 残りページ（best/active/lists/faq/guidelines/search/rss）の本家比較
- 視覚的ピクセル比較（スクリーンショット差分、Playwright）
- フッター文言の英日整合（YC/Apply/Security 系）

## 検証
- \`npm run check\`: 既存エラー8件・警告3件はすべて本変更と無関係（item, newcomments, user/[id]/comments のレガシー由来）
- 本変更による新規エラー・警告なし