### PR TITLE
fix: #56 スマホ幅表示を本家HNに合わせる

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -165,7 +165,9 @@ Single breakpoint:
 | > 750px  | `85%` width |
 | ≤ 750px  | `100%` width |
 
-No other responsive adaptations. Form inputs keep fixed widths.
+At ≤ 750px, the orange header allows `flex-wrap: wrap` so the navigation drops onto a second line below the site name (matching HN's natural inline-wrap behaviour). The site name itself uses `white-space: nowrap` to prevent mid-word breaks of 「ハッカーのろし」.
+
+At ≤ 750px, fixed-width form inputs (`300px` text, `500px` textarea) and the form's `40px` left padding shrink to fit the viewport (`width: 100%; max-width: <original>` and `padding-left: 10px`) so the page doesn't horizontally overflow on phones. Original desktop widths are preserved for ≥ 750px.
 
 ## 9. Agent Prompt Guide
 

--- a/src/app.css
+++ b/src/app.css
@@ -64,12 +64,18 @@ a:hover {
 	.hn-form input[type='password'],
 	.hn-form input[type='url'] {
 		width: 100%;
-		max-width: 300px;
+		max-width: 220px;
 	}
 
 	.hn-form textarea {
 		width: 100%;
 		max-width: 500px;
+	}
+
+	/* Tables inside forms must not exceed the form content box.
+	   Without this, the input column widens the table past 100%. */
+	.hn-form table {
+		max-width: 100%;
 	}
 
 	.comment-form textarea {
@@ -82,11 +88,20 @@ a:hover {
 		max-width: 200px;
 	}
 
-	/* Reduce 40px form indent on narrow viewports — at 375px that ate
+	/* Remove 40px form indent on narrow viewports — at 375px that ate
 	   ~11% of usable width. HN uses near-zero left padding on mobile. */
 	.hn-form,
 	.more-link {
-		padding-left: 10px;
+		padding-left: 0;
+	}
+
+	/* Long words/URLs in user-generated text must wrap on mobile.
+	   Without this, a single long token can push the page out. */
+	.item-detail .item-text,
+	.story-title-line,
+	.user-profile {
+		overflow-wrap: anywhere;
+		word-break: break-word;
 	}
 }
 

--- a/src/app.css
+++ b/src/app.css
@@ -40,6 +40,22 @@ a:hover {
 	.hn-page {
 		width: 100%;
 	}
+
+	/* Allow header contents to wrap onto a second line on narrow viewports.
+	   On HN, the nav (new | past | comments | ...) wraps below the site name
+	   when there isn't room. We mirror that behaviour. */
+	.hn-header {
+		flex-wrap: wrap;
+	}
+
+	.hn-header-left {
+		flex-wrap: wrap;
+		flex: 1 1 auto;
+	}
+
+	.hn-header-nav {
+		flex-wrap: wrap;
+	}
 }
 
 /* Header */
@@ -98,6 +114,7 @@ a:hover {
 	font-weight: bold;
 	margin-left: 1px;
 	margin-right: 5px;
+	white-space: nowrap;
 }
 
 .hn-header-nav {

--- a/src/app.css
+++ b/src/app.css
@@ -56,6 +56,38 @@ a:hover {
 	.hn-header-nav {
 		flex-wrap: wrap;
 	}
+
+	/* Forms: shrink fixed-width inputs/textareas on narrow viewports
+	   so the page doesn't horizontally overflow. HN itself uses default
+	   browser-sized inputs which naturally fit within mobile widths. */
+	.hn-form input[type='text'],
+	.hn-form input[type='password'],
+	.hn-form input[type='url'] {
+		width: 100%;
+		max-width: 300px;
+	}
+
+	.hn-form textarea {
+		width: 100%;
+		max-width: 500px;
+	}
+
+	.comment-form textarea {
+		width: 100%;
+		min-width: 0;
+	}
+
+	.hn-footer-search input {
+		width: 100%;
+		max-width: 200px;
+	}
+
+	/* Reduce 40px form indent on narrow viewports — at 375px that ate
+	   ~11% of usable width. HN uses near-zero left padding on mobile. */
+	.hn-form,
+	.more-link {
+		padding-left: 10px;
+	}
 }
 
 /* Header */


### PR DESCRIPTION
## Summary
- ヘッダ・ナビをスマホ幅で本家HNと同じく折り返し表示にする (`a0dbfca`)
- フォーム入力幅と左パディングをスマホ幅で縮め、右端にはみ出さないようにする (`b8bec30`)
- ログイン/forgot のフォームで `<table>` が input 列に押されてビューポート外（docW=426px）にはみ出していた問題を修正 (`b7931df`)
  - `.hn-form table { max-width: 100% }` を追加
  - 入力 `max-width` を 300px → 220px
  - `.hn-form` / `.more-link` の左パディングを 10px → 0
  - 念のため `.item-text` / `.story-title-line` / `.user-profile` に `overflow-wrap` を追加

## 検証
375×812 (iPhone X 相当) で水平オーバーフローを確認。
front / newest / ask / item / user / faq / guidelines いずれも docW == winW (375px) を確認。
login / forgot は修正前 docW=426px → 修正後 375px に収まる想定（CF Pages デプロイ後に再検証）。

## 原則
DESIGN.md 1.1「視覚的には本家HN完全一致、DOMは現代CSS」に従い、pt 単位・750px breakpoint・テーブル構造は維持。CSSのみで調整。

Closes #56