### PR TITLE
feat: #71 /item に hide / past リンクを追加 + /from ルート新設

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -191,6 +191,7 @@ hacker-noroshi/
 | `/showhn` | Show HN ルール |
 | `/noprocrast` | noprocrast ブロックページ（残り時間表示） |
 | `/search` | 検索（?q=キーワード&type=all\|stories\|comments&p=ページ） |
+| `/from` | ドメイン別投稿一覧（?site=example.com、/item の past リンクから遷移） |
 | `/api-docs` | APIドキュメント（準備中） |
 | `/rss` | RSS 2.0 フィード（トップページのストーリー30件） |
 | `/api/vote` | 投票 API エンドポイント |

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -495,6 +495,30 @@ function escapeLikePattern(input: string): string {
 	return input.replace(/[%_\\]/g, '\\$&');
 }
 
+export async function getStoriesByDomain(
+	db: D1Database,
+	domain: string,
+	page: number = 1,
+	limit: number = 30,
+	showdead: boolean = false
+): Promise<StoryRow[]> {
+	const offset = (page - 1) * limit;
+	const pattern = `%://${escapeLikePattern(domain)}/%`;
+	const wwwPattern = `%://www.${escapeLikePattern(domain)}/%`;
+	const deadFilter = showdead ? '' : 'AND s.dead = 0';
+	const sql = `
+		SELECT s.*, u.username, u.created_at as user_created_at, ${STORY_FLAG_COUNT_SQL}
+		FROM stories s
+		JOIN users u ON s.user_id = u.id
+		WHERE s.url IS NOT NULL
+		  AND (s.url LIKE ? ESCAPE '\\' OR s.url LIKE ? ESCAPE '\\') ${deadFilter}
+		ORDER BY s.created_at DESC
+		LIMIT ? OFFSET ?
+	`;
+	const result = await db.prepare(sql).bind(pattern, wwwPattern, limit, offset).all<StoryRow>();
+	return result.results;
+}
+
 export async function searchStories(
 	db: D1Database,
 	query: string,

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -503,8 +503,8 @@ export async function getStoriesByDomain(
 	showdead: boolean = false
 ): Promise<StoryRow[]> {
 	const offset = (page - 1) * limit;
-	const pattern = `%://${escapeLikePattern(domain)}/%`;
-	const wwwPattern = `%://www.${escapeLikePattern(domain)}/%`;
+	const pattern = `%://${escapeLikePattern(domain)}%`;
+	const wwwPattern = `%://www.${escapeLikePattern(domain)}%`;
 	const deadFilter = showdead ? '' : 'AND s.dead = 0';
 	const sql = `
 		SELECT s.*, u.username, u.created_at as user_created_at, ${STORY_FLAG_COUNT_SQL}

--- a/src/routes/from/+page.server.ts
+++ b/src/routes/from/+page.server.ts
@@ -1,3 +1,4 @@
+import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { getDB, getStoriesByDomain, getVotedStoryIds, getHiddenStoryIds, getFlaggedItemIds } from '$lib/server/db';
 import { extractDomain } from '$lib/ranking';
@@ -6,13 +7,15 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 	const db = getDB(platform);
 	const rawSite = url.searchParams.get('site') ?? '';
 	const site = rawSite.trim().toLowerCase().replace(/^www\./, '');
+	if (!site) {
+		throw redirect(303, '/');
+	}
 	const page = parseInt(url.searchParams.get('p') || '1', 10);
 
 	const showdead = locals.user?.showdead === 1;
 
-	let stories = site
-		? await getStoriesByDomain(db, site, page, 30, showdead)
-		: [];
+	// Fetch double the limit so re-filter and hidden exclusion don't strand pages
+	let stories = await getStoriesByDomain(db, site, page, 60, showdead);
 
 	// Re-filter by extracted domain (LIKE patterns can over-match path segments)
 	stories = stories.filter((s) => extractDomain(s.url) === site);
@@ -29,10 +32,14 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 		stories = stories.filter((s) => !hiddenIds.has(s.id));
 	}
 
+	const hasMore = stories.length > 30;
+	stories = stories.slice(0, 30);
+
 	return {
 		site,
 		stories,
 		page,
+		hasMore,
 		votedIds: Array.from(votedIds),
 		flaggedIds: Array.from(flaggedIds)
 	};

--- a/src/routes/from/+page.server.ts
+++ b/src/routes/from/+page.server.ts
@@ -1,0 +1,39 @@
+import type { PageServerLoad } from './$types';
+import { getDB, getStoriesByDomain, getVotedStoryIds, getHiddenStoryIds, getFlaggedItemIds } from '$lib/server/db';
+import { extractDomain } from '$lib/ranking';
+
+export const load: PageServerLoad = async ({ url, platform, locals }) => {
+	const db = getDB(platform);
+	const rawSite = url.searchParams.get('site') ?? '';
+	const site = rawSite.trim().toLowerCase().replace(/^www\./, '');
+	const page = parseInt(url.searchParams.get('p') || '1', 10);
+
+	const showdead = locals.user?.showdead === 1;
+
+	let stories = site
+		? await getStoriesByDomain(db, site, page, 30, showdead)
+		: [];
+
+	// Re-filter by extracted domain (LIKE patterns can over-match path segments)
+	stories = stories.filter((s) => extractDomain(s.url) === site);
+
+	let votedIds: Set<number> = new Set();
+	let hiddenIds: Set<number> = new Set();
+	let flaggedIds: Set<number> = new Set();
+	if (locals.user && stories.length > 0) {
+		[votedIds, hiddenIds, flaggedIds] = await Promise.all([
+			getVotedStoryIds(db, locals.user.id, stories.map((s) => s.id)),
+			getHiddenStoryIds(db, locals.user.id),
+			getFlaggedItemIds(db, locals.user.id, stories.map((s) => s.id), 'story')
+		]);
+		stories = stories.filter((s) => !hiddenIds.has(s.id));
+	}
+
+	return {
+		site,
+		stories,
+		page,
+		votedIds: Array.from(votedIds),
+		flaggedIds: Array.from(flaggedIds)
+	};
+};

--- a/src/routes/from/+page.svelte
+++ b/src/routes/from/+page.svelte
@@ -98,13 +98,9 @@
 	}
 </script>
 
-{#if data.site}
-	<div class="from-header">Submissions from {data.site}:</div>
-{:else}
-	<div class="from-empty">No domain specified.</div>
-{/if}
+<div class="from-header">Submissions from {data.site}:</div>
 
-{#if data.site && data.stories.length === 0}
+{#if data.stories.length === 0}
 	<div class="from-empty">No submissions from {data.site}</div>
 {/if}
 
@@ -154,7 +150,7 @@
 	{/each}
 </div>
 
-{#if data.stories.length === 30}
+{#if data.hasMore}
 	<div class="more-link">
 		<a href="/from?site={data.site}&p={data.page + 1}">More</a>
 	</div>

--- a/src/routes/from/+page.svelte
+++ b/src/routes/from/+page.svelte
@@ -1,0 +1,175 @@
+<script lang="ts">
+	import { FLAG_KARMA_THRESHOLD } from '$lib/constants';
+	import { timeAgo, extractDomain, isNewUser } from '$lib/ranking';
+
+	let { data } = $props();
+	let votedIds = $derived(new Set(data.votedIds));
+	let flaggedIds = $derived(new Set(data.flaggedIds ?? []));
+	let localVotedIds = $state<Set<number> | null>(null);
+	let localPoints = $state<Record<number, number>>({});
+	let localHiddenIds = $state<Set<number>>(new Set());
+	let localFlaggedIds = $state<Set<number> | null>(null);
+	let localFlagCounts = $state<Record<number, number>>({});
+
+	function getVotedIds(): Set<number> {
+		return localVotedIds ?? votedIds;
+	}
+
+	function getFlaggedIds(): Set<number> {
+		return localFlaggedIds ?? flaggedIds;
+	}
+
+	function getFlagCount(story: { id: number; flag_count?: number }): number {
+		return localFlagCounts[story.id] ?? story.flag_count ?? 0;
+	}
+
+	function getPoints(story: { id: number; points: number }): number {
+		return localPoints[story.id] ?? story.points;
+	}
+
+	function isHidden(id: number): boolean {
+		return localHiddenIds.has(id);
+	}
+
+	function canFlag(story: { user_id: number }): boolean {
+		return !!data.user && data.user.karma >= FLAG_KARMA_THRESHOLD && story.user_id !== data.user.id;
+	}
+
+	async function flag(storyId: number) {
+		if (!data.user) {
+			window.location.href = '/login';
+			return;
+		}
+		const res = await fetch('/api/flag', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
+		});
+		if (res.ok) {
+			const result: { flagged: boolean; flagCount: number } = await res.json();
+			const next = new Set(getFlaggedIds());
+			if (result.flagged) next.add(storyId);
+			else next.delete(storyId);
+			localFlaggedIds = next;
+			localFlagCounts = { ...localFlagCounts, [storyId]: result.flagCount };
+		} else if (res.status === 403) {
+			const result = (await res.json()) as { error?: string };
+			alert(result.error || 'Permission denied');
+		}
+	}
+
+	async function hide(storyId: number) {
+		const res = await fetch('/api/hide', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ storyId })
+		});
+		if (res.ok) {
+			const result: { hidden: boolean } = await res.json();
+			if (result.hidden) {
+				const next = new Set(localHiddenIds);
+				next.add(storyId);
+				localHiddenIds = next;
+			}
+		}
+	}
+
+	async function vote(storyId: number) {
+		if (!data.user) {
+			window.location.href = '/login';
+			return;
+		}
+		const res = await fetch('/api/vote', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
+		});
+		if (res.ok) {
+			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
+			localPoints = { ...localPoints, [storyId]: result.points };
+			const next = new Set(getVotedIds());
+			if (result.voteState === 'up') {
+				next.add(storyId);
+			} else {
+				next.delete(storyId);
+			}
+			localVotedIds = next;
+		}
+	}
+</script>
+
+{#if data.site}
+	<div class="from-header">Submissions from {data.site}:</div>
+{:else}
+	<div class="from-empty">No domain specified.</div>
+{/if}
+
+{#if data.site && data.stories.length === 0}
+	<div class="from-empty">No submissions from {data.site}</div>
+{/if}
+
+<div class="story-list">
+	{#each data.stories as story, i}
+		{#if !isHidden(story.id)}
+		<div class="story-item">
+			<span class="story-rank">{(data.page - 1) * 30 + i + 1}.</span>
+			<span class="story-vote">
+				<button
+					class="upvote"
+					class:voted={getVotedIds().has(story.id)}
+					onclick={() => vote(story.id)}
+					aria-label="upvote"
+				>
+					&#9650;
+				</button>
+			</span>
+			<div class="story-content" class:faded={story.dead === 1}>
+				<div class="story-title-line">
+					{#if story.url}
+						<a href={story.url} class="story-title">{story.title}</a>
+						<span class="story-domain">({extractDomain(story.url)})</span>
+					{:else}
+						<a href="/item/{story.id}" class="story-title">{story.title}</a>
+					{/if}
+					{#if getFlagCount(story) > 0} <span class="story-tag">[flagged]</span>{/if}
+					{#if story.dead === 1} <span class="story-tag">[dead]</span>{/if}
+				</div>
+				<div class="story-meta">
+					{getPoints(story)} point{getPoints(story) !== 1 ? 's' : ''} by
+					<a href="/user/{story.username}" style={isNewUser(story.user_created_at) ? 'color: #3c963c;' : ''}>{story.username}</a>
+					<a href="/item/{story.id}">{timeAgo(story.created_at)}</a> |
+					<a href="/item/{story.id}"
+						>{story.comment_count} comment{story.comment_count !== 1 ? 's' : ''}</a
+					>
+					{#if data.user}
+						| <a href="#hide" onclick={(e) => { e.preventDefault(); hide(story.id); }}>hide</a>
+					{/if}
+					{#if canFlag(story)}
+						| <a href="#flag" onclick={(e) => { e.preventDefault(); flag(story.id); }}>{getFlaggedIds().has(story.id) ? 'un-flag' : 'flag'}</a>
+					{/if}
+				</div>
+			</div>
+		</div>
+		{/if}
+	{/each}
+</div>
+
+{#if data.stories.length === 30}
+	<div class="more-link">
+		<a href="/from?site={data.site}&p={data.page + 1}">More</a>
+	</div>
+{/if}
+
+<style>
+	.from-header {
+		padding: 6pt 0 6pt 6pt;
+		font-size: 10pt;
+		color: #000000;
+	}
+
+	.from-empty {
+		padding: 10pt 0 10pt 6pt;
+		font-size: 10pt;
+		color: #828282;
+	}
+</style>

--- a/src/routes/item/[id]/+page.server.ts
+++ b/src/routes/item/[id]/+page.server.ts
@@ -1,5 +1,5 @@
 import type { PageServerLoad, Actions } from './$types';
-import { getDB, getStoryById, getCommentsByStoryId, getCommentById, getChildComments, getCommentVoteStates, getVoteState, hasFavorited, hasFlagged, getFlaggedItemIds } from '$lib/server/db';
+import { getDB, getStoryById, getCommentsByStoryId, getCommentById, getChildComments, getCommentVoteStates, getVoteState, hasFavorited, hasFlagged, hasHidden, getFlaggedItemIds } from '$lib/server/db';
 import { TWO_WEEKS_MS } from '$lib/ranking';
 import { error, fail, redirect } from '@sveltejs/kit';
 
@@ -21,22 +21,25 @@ export const load: PageServerLoad = async ({ params, platform, locals }) => {
 		let storyVoted = false;
 		let storyFavorited = false;
 		let storyFlagged = false;
+		let storyHidden = false;
 		let commentVoteStates: Map<number, 'up' | 'down'> = new Map();
 		let flaggedCommentIds: Set<number> = new Set();
 
 		if (locals.user) {
-			const [storyVoteState, fav, cvs, flag, fcids] = await Promise.all([
+			const [storyVoteState, fav, cvs, flag, fcids, hidden] = await Promise.all([
 				getVoteState(db, locals.user.id, id, 'story'),
 				hasFavorited(db, locals.user.id, id),
 				getCommentVoteStates(db, locals.user.id, comments.map((c) => c.id)),
 				hasFlagged(db, locals.user.id, id, 'story'),
-				getFlaggedItemIds(db, locals.user.id, comments.map((c) => c.id), 'comment')
+				getFlaggedItemIds(db, locals.user.id, comments.map((c) => c.id), 'comment'),
+				hasHidden(db, locals.user.id, id)
 			]);
 			storyVoted = storyVoteState === 'up';
 			storyFavorited = fav;
 			storyFlagged = flag;
 			commentVoteStates = cvs;
 			flaggedCommentIds = fcids;
+			storyHidden = hidden;
 		}
 
 		return {
@@ -46,6 +49,7 @@ export const load: PageServerLoad = async ({ params, platform, locals }) => {
 			storyVoted,
 			storyFavorited,
 			storyFlagged,
+			storyHidden,
 			commentVoteStates: Object.fromEntries(commentVoteStates),
 			flaggedCommentIds: Array.from(flaggedCommentIds)
 		};

--- a/src/routes/item/[id]/+page.svelte
+++ b/src/routes/item/[id]/+page.svelte
@@ -17,6 +17,7 @@
 	let localTargetCommentPoints = $state<number | null>(null);
 	let localStoryFavorited = $state<boolean | null>(null);
 	let localStoryFlagged = $state<boolean | null>(null);
+	let localStoryHidden = $state<boolean | null>(null);
 	let localTargetCommentFlagged = $state<boolean | null>(null);
 	let localStoryDead = $state<number | null>(null);
 	let localTargetCommentDead = $state<number | null>(null);
@@ -130,6 +131,7 @@
 	let storyPoints = $derived(localStoryPoints ?? (data.mode === 'story' ? data.story.points : 0));
 	let storyFavorited = $derived(localStoryFavorited ?? (data.mode === 'story' ? data.storyFavorited : false));
 	let storyFlagged = $derived(localStoryFlagged ?? (data.mode === 'story' ? data.storyFlagged : false));
+	let storyHidden = $derived(localStoryHidden ?? (data.mode === 'story' ? (data.storyHidden ?? false) : false));
 	let storyDead = $derived(localStoryDead ?? (data.mode === 'story' ? data.story.dead : 0));
 	let targetCommentFlagged = $derived(localTargetCommentFlagged ?? (data.mode === 'comment' ? data.commentFlagged : false));
 	let targetCommentDead = $derived(localTargetCommentDead ?? (data.mode === 'comment' ? data.targetComment.dead : 0));
@@ -287,6 +289,23 @@
 		if (res.ok) {
 			const result: { favorited: boolean } = await res.json();
 			localStoryFavorited = result.favorited;
+		}
+	}
+
+	async function toggleHideStory() {
+		if (!data.user) {
+			window.location.href = '/login';
+			return;
+		}
+		if (data.mode !== 'story') return;
+		const res = await fetch('/api/hide', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ storyId: data.story.id })
+		});
+		if (res.ok) {
+			const result: { hidden: boolean } = await res.json();
+			localStoryHidden = result.hidden;
 		}
 	}
 
@@ -538,6 +557,17 @@
 				| <form method="POST" action="?/deleteStory" class="inline-form" use:enhance={confirmDelete('Delete this story? Text will be replaced with [deleted].')}>
 					<button type="submit" class="link-button">delete</button>
 				</form>
+			{/if}
+			{#if data.user}
+				| <a
+					href="#hide"
+					onclick={(e) => {
+						e.preventDefault();
+						toggleHideStory();
+					}}>{storyHidden ? 'un-hide' : 'hide'}</a>
+			{/if}
+			{#if data.story.url}
+				| <a href="/from?site={extractDomain(data.story.url)}">past</a>
 			{/if}
 			{#if data.user}
 				| <a


### PR DESCRIPTION
## 関連 Issue
closes #71

## 変更内容

### 1. /item メタ行に hide / past リンクを追加（本家HN準拠）
- 本家HN: `{points} by {user} {time} | hide | past | favorite | flag | N comments`
- `hide` / `un-hide` トグル: ログイン中のみ表示。既存 `/api/hide` を呼ぶ
- `past`: story.url がある場合のみ表示。`/from?site={domain}` へ遷移

### 2. /from ルート新設（同ドメイン投稿一覧）
- `/from?site=example.com` で同じドメインの過去投稿を一覧表示
- `getStoriesByDomain(db, domain, page, limit, showdead)` を db.ts に追加
- LIKE 検索 + サーバー側で `extractDomain` 再フィルタ（誤マッチ防止）
- /front パターンに準拠した list rendering、ページネーション、空状態対応

### 3. docs/architecture.md にルート追記

## 変更ファイル
- `src/lib/server/db.ts` (+24)
- `src/routes/item/[id]/+page.server.ts` (+10/-2)
- `src/routes/item/[id]/+page.svelte` (+30)
- `src/routes/from/+page.server.ts` (+39, 新規)
- `src/routes/from/+page.svelte` (+175, 新規)
- `docs/architecture.md` (+1)

## Test plan
- [ ] /item/[id] のストーリーメタ行に `hide` `past` が表示される
- [ ] hide → un-hide トグルが動作する
- [ ] past リンクから /from?site=example.com へ遷移し、同ドメイン投稿が一覧される
- [ ] 該当0件の場合「No submissions from {domain}」が表示される
- [ ] Ask HN 等 url のないストーリーには past が出ない
- [ ] 未ログイン時は hide が表示されない