### PR TITLE
fix: #70 noprocrast 文言を本家HNの命令形ニュアンスに合わせる

### DIFF
--- a/src/routes/noprocrast/+page.svelte
+++ b/src/routes/noprocrast/+page.svelte
@@ -8,6 +8,6 @@
 
 <div style="padding: 40px;">
 	<p style="font-family: Verdana, Geneva, sans-serif; font-size: 10pt;">
-		仕事に戻りましょう！あと {data.remaining} 分は閲覧できません。
+		仕事に戻れ！あと {data.remaining} 分は閲覧できません。
 	</p>
 </div>


### PR DESCRIPTION
## 関連 Issue
closes #70

## 変更
本家HN noprocrast 表示文 "Get back to work!" のぶっきらぼうな命令形に合わせ、当方の文言を変更。

| | 変更前 | 変更後 |
|---|---|---|
| noprocrast ページ | 仕事に戻りましょう！ | 仕事に戻れ！ |

「ましょう」（包摂・誘い）から命令形に変えることで、HNの「直接ユーザーに突きつける」トーンを再現。プログラマー向けの簡潔さも担保。

## Test plan
- [ ] noprocrast 制限中にアクセスして文言が "仕事に戻れ！あと N 分は閲覧できません。" と表示される