### PR TITLE
feat: #68 未実装ページ7つを実装（leaders/bestcomments/highlights/shownew/asknew/noobstories/noobcomments）

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -175,7 +175,14 @@ hacker-noroshi/
 | `/newcomments` | 全ストーリーの最新コメント一覧 |
 | `/best` | 高スコアのストーリー一覧 |
 | `/active` | アクティブな議論一覧（最新コメント時刻順） |
-| `/lists` | ブラウズリンク集（本家HN順: front, show, ask, best, active, newcomments） |
+| `/shownew` | 新着順 Show HN（時系列） |
+| `/asknew` | 新着順 Ask HN（時系列） |
+| `/bestcomments` | 直近30日の高得点コメント上位30件 |
+| `/highlights` | 全期間の高得点コメント上位30件 |
+| `/noobstories` | 新規ユーザー（過去14日以内）の投稿 |
+| `/noobcomments` | 新規ユーザー（過去14日以内）のコメント |
+| `/leaders` | karma 上位30ユーザーのリーダーボード |
+| `/lists` | ブラウズリンク集（本家HN順、実装済み13項目を掲載） |
 | `/item/[id]` | 投稿詳細 or コメントパーマリンク + コメントスレッド + 編集 |
 | `/user/[id]` | ユーザープロフィール + 編集 |
 | `/user/[id]/submissions` | ユーザーの投稿一覧 |
@@ -217,6 +224,10 @@ hacker-noroshi/
 | `getCommentsByUserId()` | ユーザーのコメント一覧（story_title 付き） |
 | `getActiveStories()` | アクティブな議論（最新コメント時刻順にストーリーをソート） |
 | `getRecentComments()` | 全ストーリーの最新コメント一覧（/newcomments 用） |
+| `getTopUsersByKarma()` | karma 順ユーザー一覧（/leaders 用） |
+| `getBestComments()` | 高得点コメント一覧（sinceMs で期間制限可、/bestcomments と /highlights 用） |
+| `getStoriesByNewUsers()` | 新規ユーザーの投稿一覧（/noobstories 用） |
+| `getCommentsByNewUsers()` | 新規ユーザーのコメント一覧（/noobcomments 用） |
 | `getVoteState()` | 投票状態取得（'up' / 'down' / null） |
 | `getVotedStoryIds()` | upvote済みストーリーID一括取得 |
 | `getCommentVoteStates()` | コメント投票状態一括取得（Map<id, 'up'/'down'>） |

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -611,6 +611,130 @@ export async function getRecentComments(
 	return filtered.slice(0, limit);
 }
 
+export async function getTopUsersByKarma(
+	db: D1Database,
+	page: number = 1,
+	limit: number = 30
+): Promise<UserRow[]> {
+	const offset = (page - 1) * limit;
+	const result = await db
+		.prepare(
+			`SELECT * FROM users
+			ORDER BY karma DESC, created_at ASC
+			LIMIT ? OFFSET ?`
+		)
+		.bind(limit, offset)
+		.all<UserRow>();
+	return result.results;
+}
+
+export async function getBestComments(
+	db: D1Database,
+	options: {
+		sinceMs?: number; // null/undefined: 全期間
+		page?: number;
+		limit?: number;
+		currentUserId?: number;
+		showdead?: boolean;
+	} = {}
+): Promise<(CommentRow & { story_title: string })[]> {
+	const { sinceMs, page = 1, limit = 30, currentUserId, showdead = false } = options;
+	const fetchLimit = limit * 3;
+	const offset = (page - 1) * limit;
+	const conds: string[] = [];
+	const params: (string | number)[] = [];
+
+	if (!showdead) conds.push('c.dead = 0');
+	if (sinceMs !== undefined) {
+		const sinceIso = new Date(Date.now() - sinceMs).toISOString().replace(/\.\d{3}Z$/, 'Z');
+		conds.push('c.created_at >= ?');
+		params.push(sinceIso);
+	}
+	const whereClause = conds.length > 0 ? `WHERE ${conds.join(' AND ')}` : '';
+
+	const sql = `
+		SELECT c.*, u.username, u.created_at as user_created_at, u.delay as author_delay, s.title as story_title, ${COMMENT_FLAG_COUNT_SQL}
+		FROM comments c
+		JOIN users u ON c.user_id = u.id
+		JOIN stories s ON c.story_id = s.id
+		${whereClause}
+		ORDER BY c.points DESC, c.created_at DESC
+		LIMIT ? OFFSET ?
+	`;
+	params.push(fetchLimit, offset);
+	const result = await db
+		.prepare(sql)
+		.bind(...params)
+		.all<CommentRow & { story_title: string; author_delay: number }>();
+
+	const now = Date.now();
+	const filtered = result.results.filter((c) => {
+		if (c.user_id === currentUserId) return true;
+		if (c.author_delay <= 0) return true;
+		const visibleAt = new Date(c.created_at).getTime() + c.author_delay * 60 * 1000;
+		return now >= visibleAt;
+	});
+	return filtered.slice(0, limit);
+}
+
+export async function getStoriesByNewUsers(
+	db: D1Database,
+	thresholdMs: number,
+	page: number = 1,
+	limit: number = 30,
+	showdead: boolean = false
+): Promise<StoryRow[]> {
+	const offset = (page - 1) * limit;
+	const sinceIso = new Date(Date.now() - thresholdMs).toISOString().replace(/\.\d{3}Z$/, 'Z');
+	const deadFilter = showdead ? '' : 'AND s.dead = 0';
+	const sql = `
+		SELECT s.*, u.username, u.created_at as user_created_at, ${STORY_FLAG_COUNT_SQL}
+		FROM stories s
+		JOIN users u ON s.user_id = u.id
+		WHERE u.created_at >= ? ${deadFilter}
+		ORDER BY s.created_at DESC
+		LIMIT ? OFFSET ?
+	`;
+	const result = await db.prepare(sql).bind(sinceIso, limit, offset).all<StoryRow>();
+	return result.results;
+}
+
+export async function getCommentsByNewUsers(
+	db: D1Database,
+	thresholdMs: number,
+	page: number = 1,
+	limit: number = 30,
+	currentUserId?: number,
+	showdead: boolean = false
+): Promise<(CommentRow & { story_title: string })[]> {
+	const fetchLimit = limit * 3;
+	const offset = (page - 1) * limit;
+	const sinceIso = new Date(Date.now() - thresholdMs).toISOString().replace(/\.\d{3}Z$/, 'Z');
+	const deadFilter = showdead ? '' : 'AND c.dead = 0';
+	const sql = `
+		SELECT c.*, u.username, u.created_at as user_created_at, u.delay as author_delay, s.title as story_title, ${COMMENT_FLAG_COUNT_SQL}
+		FROM comments c
+		JOIN users u ON c.user_id = u.id
+		JOIN stories s ON c.story_id = s.id
+		WHERE u.created_at >= ? ${deadFilter}
+		ORDER BY c.created_at DESC
+		LIMIT ? OFFSET ?
+	`;
+	const result = await db
+		.prepare(sql)
+		.bind(sinceIso, fetchLimit, offset)
+		.all<CommentRow & { story_title: string; author_delay: number }>();
+
+	const now = Date.now();
+	const filtered = result.results.filter((c) => {
+		if (c.user_id === currentUserId) return true;
+		if (c.author_delay <= 0) return true;
+		const visibleAt = new Date(c.created_at).getTime() + c.author_delay * 60 * 1000;
+		return now >= visibleAt;
+	});
+	return filtered.slice(0, limit);
+}
+
 export async function hasFlagged(
 	db: D1Database,
 	userId: number,

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -611,20 +611,24 @@ export async function getRecentComments(
 	return filtered.slice(0, limit);
 }
 
+export type LeaderRow = Pick<UserRow, 'id' | 'username' | 'karma' | 'created_at'>;
+
 export async function getTopUsersByKarma(
 	db: D1Database,
 	page: number = 1,
 	limit: number = 30
-): Promise<UserRow[]> {
+): Promise<LeaderRow[]> {
 	const offset = (page - 1) * limit;
+	// 列限定: password_hash など機微フィールドを取らない（将来のフィールド追加事故も回避）
+	// 同 karma は古参優先（本家HN準拠）
 	const result = await db
 		.prepare(
-			`SELECT * FROM users
+			`SELECT id, username, karma, created_at FROM users
 			ORDER BY karma DESC, created_at ASC
 			LIMIT ? OFFSET ?`
 		)
 		.bind(limit, offset)
-		.all<UserRow>();
+		.all<LeaderRow>();
 	return result.results;
 }
 
@@ -677,6 +681,8 @@ export async function getBestComments(
 	return filtered.slice(0, limit);
 }
 
+// 新規ユーザー判定は呼び出し側が thresholdMs を指定する。/noobstories では TWO_WEEKS_MS（14日）を渡す。
+// `isNewUser()` のグリーン表示と一貫させるため、しきい値は両者で揃えること。
 export async function getStoriesByNewUsers(
 	db: D1Database,
 	thresholdMs: number,
@@ -699,6 +705,8 @@ export async function getStoriesByNewUsers(
 	return result.results;
 }
 
+// 新規ユーザー判定は呼び出し側が thresholdMs を指定する。/noobcomments では TWO_WEEKS_MS（14日）を渡す。
+// `isNewUser()` のグリーン表示と一貫させるため、しきい値は両者で揃えること。
 export async function getCommentsByNewUsers(
 	db: D1Database,
 	thresholdMs: number,

--- a/src/routes/asknew/+page.server.ts
+++ b/src/routes/asknew/+page.server.ts
@@ -1,0 +1,28 @@
+import type { PageServerLoad } from './$types';
+import { getDB, getStories, getVotedStoryIds, getHiddenStoryIds, getFlaggedItemIds } from '$lib/server/db';
+
+export const load: PageServerLoad = async ({ url, platform, locals }) => {
+	const db = getDB(platform);
+	const page = parseInt(url.searchParams.get('p') || '1', 10);
+	const showdead = locals.user?.showdead === 1;
+	let stories = await getStories(db, { type: 'ask', orderBy: 'newest', page, limit: 60, showdead });
+
+	let votedIds: Set<number> = new Set();
+	let hiddenIds: Set<number> = new Set();
+	let flaggedIds: Set<number> = new Set();
+	if (locals.user) {
+		[votedIds, hiddenIds, flaggedIds] = await Promise.all([
+			getVotedStoryIds(db, locals.user.id, stories.map((s) => s.id)),
+			getHiddenStoryIds(db, locals.user.id),
+			getFlaggedItemIds(db, locals.user.id, stories.map((s) => s.id), 'story')
+		]);
+		stories = stories.filter((s) => !hiddenIds.has(s.id)).slice(0, 30);
+	}
+
+	return {
+		stories,
+		page,
+		votedIds: Array.from(votedIds),
+		flaggedIds: Array.from(flaggedIds)
+	};
+};

--- a/src/routes/asknew/+page.server.ts
+++ b/src/routes/asknew/+page.server.ts
@@ -5,6 +5,7 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 	const db = getDB(platform);
 	const page = parseInt(url.searchParams.get('p') || '1', 10);
 	const showdead = locals.user?.showdead === 1;
+	// 60件取得して hidden 除外後にも 30件埋まる確率を上げる
 	let stories = await getStories(db, { type: 'ask', orderBy: 'newest', page, limit: 60, showdead });
 
 	let votedIds: Set<number> = new Set();
@@ -16,12 +17,16 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 			getHiddenStoryIds(db, locals.user.id),
 			getFlaggedItemIds(db, locals.user.id, stories.map((s) => s.id), 'story')
 		]);
-		stories = stories.filter((s) => !hiddenIds.has(s.id)).slice(0, 30);
+		stories = stories.filter((s) => !hiddenIds.has(s.id));
 	}
+
+	const hasMore = stories.length > 30;
+	stories = stories.slice(0, 30);
 
 	return {
 		stories,
 		page,
+		hasMore,
 		votedIds: Array.from(votedIds),
 		flaggedIds: Array.from(flaggedIds)
 	};

--- a/src/routes/asknew/+page.svelte
+++ b/src/routes/asknew/+page.svelte
@@ -148,7 +148,7 @@
 	{/each}
 </div>
 
-{#if data.stories.length === 30}
+{#if data.hasMore}
 	<div class="more-link">
 		<a href="/asknew?p={data.page + 1}">More</a>
 	</div>

--- a/src/routes/asknew/+page.svelte
+++ b/src/routes/asknew/+page.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+	import { FLAG_KARMA_THRESHOLD } from '$lib/constants';
+	import { timeAgo, extractDomain, isNewUser } from '$lib/ranking';
+
+	let { data } = $props();
+	let votedIds = $derived(new Set(data.votedIds));
+	let flaggedIds = $derived(new Set(data.flaggedIds ?? []));
+	let localVotedIds = $state<Set<number> | null>(null);
+	let localPoints = $state<Record<number, number>>({});
+	let localHiddenIds = $state<Set<number>>(new Set());
+	let localFlaggedIds = $state<Set<number> | null>(null);
+	let localFlagCounts = $state<Record<number, number>>({});
+
+	function getVotedIds(): Set<number> {
+		return localVotedIds ?? votedIds;
+	}
+
+	function getFlaggedIds(): Set<number> {
+		return localFlaggedIds ?? flaggedIds;
+	}
+
+	function getFlagCount(story: { id: number; flag_count?: number }): number {
+		return localFlagCounts[story.id] ?? story.flag_count ?? 0;
+	}
+
+	function getPoints(story: { id: number; points: number }): number {
+		return localPoints[story.id] ?? story.points;
+	}
+
+	function isHidden(id: number): boolean {
+		return localHiddenIds.has(id);
+	}
+
+	function canFlag(story: { user_id: number }): boolean {
+		return !!data.user && data.user.karma >= FLAG_KARMA_THRESHOLD && story.user_id !== data.user.id;
+	}
+
+	async function flag(storyId: number) {
+		if (!data.user) {
+			window.location.href = '/login';
+			return;
+		}
+		const res = await fetch('/api/flag', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
+		});
+		if (res.ok) {
+			const result: { flagged: boolean; flagCount: number } = await res.json();
+			const next = new Set(getFlaggedIds());
+			if (result.flagged) next.add(storyId);
+			else next.delete(storyId);
+			localFlaggedIds = next;
+			localFlagCounts = { ...localFlagCounts, [storyId]: result.flagCount };
+		} else if (res.status === 403) {
+			const result = (await res.json()) as { error?: string };
+			alert(result.error || 'Permission denied');
+		}
+	}
+
+	async function hide(storyId: number) {
+		const res = await fetch('/api/hide', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ storyId })
+		});
+		if (res.ok) {
+			const result: { hidden: boolean } = await res.json();
+			if (result.hidden) {
+				const next = new Set(localHiddenIds);
+				next.add(storyId);
+				localHiddenIds = next;
+			}
+		}
+	}
+
+	async function vote(storyId: number) {
+		if (!data.user) {
+			window.location.href = '/login';
+			return;
+		}
+		const res = await fetch('/api/vote', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
+		});
+		if (res.ok) {
+			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
+			localPoints = { ...localPoints, [storyId]: result.points };
+			const next = new Set(getVotedIds());
+			if (result.voteState === 'up') {
+				next.add(storyId);
+			} else {
+				next.delete(storyId);
+			}
+			localVotedIds = next;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>New Ask HN | ハッカーのろし</title>
+</svelte:head>
+
+<div class="story-list">
+	{#each data.stories as story, i}
+		{#if !isHidden(story.id)}
+		<div class="story-item">
+			<span class="story-rank">{(data.page - 1) * 30 + i + 1}.</span>
+			<span class="story-vote">
+				<button
+					class="upvote"
+					class:voted={getVotedIds().has(story.id)}
+					onclick={() => vote(story.id)}
+					aria-label="upvote"
+				>
+					&#9650;
+				</button>
+			</span>
+			<div class="story-content" class:faded={story.dead === 1}>
+				<div class="story-title-line">
+					{#if story.url}
+						<a href={story.url} class="story-title">{story.title}</a>
+						<span class="story-domain">({extractDomain(story.url)})</span>
+					{:else}
+						<a href="/item/{story.id}" class="story-title">{story.title}</a>
+					{/if}
+					{#if getFlagCount(story) > 0} <span class="story-tag">[flagged]</span>{/if}
+					{#if story.dead === 1} <span class="story-tag">[dead]</span>{/if}
+				</div>
+				<div class="story-meta">
+					{getPoints(story)} point{getPoints(story) !== 1 ? 's' : ''} by
+					<a href="/user/{story.username}" style={isNewUser(story.user_created_at) ? 'color: #3c963c;' : ''}>{story.username}</a>
+					<a href="/item/{story.id}">{timeAgo(story.created_at)}</a> |
+					<a href="/item/{story.id}"
+						>{story.comment_count} comment{story.comment_count !== 1 ? 's' : ''}</a
+					>
+					{#if data.user}
+						| <a href="#hide" onclick={(e) => { e.preventDefault(); hide(story.id); }}>hide</a>
+					{/if}
+					{#if canFlag(story)}
+						| <a href="#flag" onclick={(e) => { e.preventDefault(); flag(story.id); }}>{getFlaggedIds().has(story.id) ? 'un-flag' : 'flag'}</a>
+					{/if}
+				</div>
+			</div>
+		</div>
+		{/if}
+	{/each}
+</div>
+
+{#if data.stories.length === 30}
+	<div class="more-link">
+		<a href="/asknew?p={data.page + 1}">More</a>
+	</div>
+{/if}

--- a/src/routes/bestcomments/+page.server.ts
+++ b/src/routes/bestcomments/+page.server.ts
@@ -1,0 +1,33 @@
+import type { PageServerLoad } from './$types';
+import { getDB, getBestComments, getCommentVoteStates, getFlaggedItemIds } from '$lib/server/db';
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+export const load: PageServerLoad = async ({ url, platform, locals }) => {
+	const db = getDB(platform);
+	const page = parseInt(url.searchParams.get('p') || '1', 10);
+	const showdead = locals.user?.showdead === 1;
+	const comments = await getBestComments(db, {
+		sinceMs: THIRTY_DAYS_MS,
+		page,
+		limit: 30,
+		currentUserId: locals.user?.id,
+		showdead
+	});
+
+	let commentVoteStates: Map<number, 'up' | 'down'> = new Map();
+	let flaggedCommentIds: Set<number> = new Set();
+	if (locals.user) {
+		[commentVoteStates, flaggedCommentIds] = await Promise.all([
+			getCommentVoteStates(db, locals.user.id, comments.map((c) => c.id)),
+			getFlaggedItemIds(db, locals.user.id, comments.map((c) => c.id), 'comment')
+		]);
+	}
+
+	return {
+		comments,
+		commentVoteStates: Object.fromEntries(commentVoteStates),
+		flaggedCommentIds: Array.from(flaggedCommentIds),
+		page
+	};
+};

--- a/src/routes/bestcomments/+page.server.ts
+++ b/src/routes/bestcomments/+page.server.ts
@@ -7,13 +7,17 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 	const db = getDB(platform);
 	const page = parseInt(url.searchParams.get('p') || '1', 10);
 	const showdead = locals.user?.showdead === 1;
-	const comments = await getBestComments(db, {
+	// 60件取得して delay フィルタ後にも 30件埋まる確率を上げ、hasMore を確実に判定する
+	let comments = await getBestComments(db, {
 		sinceMs: THIRTY_DAYS_MS,
 		page,
-		limit: 30,
+		limit: 60,
 		currentUserId: locals.user?.id,
 		showdead
 	});
+
+	const hasMore = comments.length > 30;
+	comments = comments.slice(0, 30);
 
 	let commentVoteStates: Map<number, 'up' | 'down'> = new Map();
 	let flaggedCommentIds: Set<number> = new Set();
@@ -28,6 +32,7 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 		comments,
 		commentVoteStates: Object.fromEntries(commentVoteStates),
 		flaggedCommentIds: Array.from(flaggedCommentIds),
-		page
+		page,
+		hasMore
 	};
 };

--- a/src/routes/bestcomments/+page.svelte
+++ b/src/routes/bestcomments/+page.svelte
@@ -87,7 +87,7 @@
 	{/each}
 </div>
 
-{#if data.comments.length === 30}
+{#if data.hasMore}
 	<div class="more-link">
 		<a href="/bestcomments?p={data.page + 1}">More</a>
 	</div>

--- a/src/routes/bestcomments/+page.svelte
+++ b/src/routes/bestcomments/+page.svelte
@@ -35,7 +35,7 @@
 				[commentId]: result.voteState
 			};
 		} else if (res.status === 403) {
-			const result = await res.json();
+			const result = (await res.json()) as { error?: string };
 			alert(result.error || 'Permission denied');
 		}
 	}

--- a/src/routes/bestcomments/+page.svelte
+++ b/src/routes/bestcomments/+page.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+	import { timeAgo, isNewUser } from '$lib/ranking';
+	import { formatText } from '$lib/format';
+
+	let { data } = $props();
+	let localVoteStates = $state<Record<number, 'up' | 'down' | null> | null>(null);
+	let localPoints = $state<Record<number, number>>({});
+
+	function getVoteState(commentId: number): 'up' | 'down' | null {
+		if (localVoteStates && commentId in localVoteStates) {
+			return localVoteStates[commentId];
+		}
+		return (data.commentVoteStates as Record<number, 'up' | 'down'>)[commentId] ?? null;
+	}
+
+	function getPoints(comment: { id: number; points: number }): number {
+		return localPoints[comment.id] ?? comment.points;
+	}
+
+	async function vote(commentId: number, direction: 'up' | 'down' = 'up') {
+		if (!data.user) {
+			window.location.href = '/login';
+			return;
+		}
+		const res = await fetch('/api/vote', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ itemId: commentId, itemType: 'comment', direction })
+		});
+		if (res.ok) {
+			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
+			localPoints = { ...localPoints, [commentId]: result.points };
+			localVoteStates = {
+				...(localVoteStates ?? {}),
+				[commentId]: result.voteState
+			};
+		} else if (res.status === 403) {
+			const result = await res.json();
+			alert(result.error || 'Permission denied');
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Best Comments | ハッカーのろし</title>
+</svelte:head>
+
+<div style="padding-left: 40px;">
+	{#each data.comments as comment}
+		<div style="padding: 10px 0;">
+			<div class="comment-head">
+				<span class="comment-vote">
+					<button
+						class="upvote"
+						class:voted={getVoteState(comment.id) === 'up'}
+						onclick={() => vote(comment.id, 'up')}
+						aria-label="upvote comment"
+					>
+						&#9650;
+					</button>
+					{#if data.user && data.user.karma >= 500}
+						<button
+							class="downvote"
+							class:voted={getVoteState(comment.id) === 'down'}
+							onclick={() => vote(comment.id, 'down')}
+							aria-label="downvote comment"
+						>
+							&#9660;
+						</button>
+					{/if}
+				</span>
+				{getPoints(comment)} point{getPoints(comment) !== 1 ? 's' : ''} by
+				<a href="/user/{comment.username}" style={isNewUser(comment.user_created_at) ? 'color: #3c963c;' : ''}>{comment.username}</a>
+				<a href="/item/{comment.id}">{timeAgo(comment.created_at)}</a>
+				| <a href="/item/{comment.parent_id ?? comment.story_id}" style="color: #828282;">parent</a>
+				| <a href="/item/{comment.id}" style="color: #828282;">context</a>
+				| on: <a href="/item/{comment.story_id}">{comment.story_title}</a>
+			</div>
+			<div class="comment-text" class:faded={getPoints(comment) < 1} style="padding-left: 14px;">
+				{#each comment.text.split('\n') as paragraph}
+					{#if paragraph.trim()}
+						<p>{@html formatText(paragraph)}</p>
+					{/if}
+				{/each}
+			</div>
+		</div>
+	{/each}
+</div>
+
+{#if data.comments.length === 30}
+	<div class="more-link">
+		<a href="/bestcomments?p={data.page + 1}">More</a>
+	</div>
+{/if}

--- a/src/routes/highlights/+page.server.ts
+++ b/src/routes/highlights/+page.server.ts
@@ -5,13 +5,17 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 	const db = getDB(platform);
 	const page = parseInt(url.searchParams.get('p') || '1', 10);
 	const showdead = locals.user?.showdead === 1;
-	const comments = await getBestComments(db, {
+	// 60件取得して delay フィルタ後にも 30件埋まる確率を上げ、hasMore を確実に判定する
+	let comments = await getBestComments(db, {
 		// sinceMs を指定しない => 全期間
 		page,
-		limit: 30,
+		limit: 60,
 		currentUserId: locals.user?.id,
 		showdead
 	});
+
+	const hasMore = comments.length > 30;
+	comments = comments.slice(0, 30);
 
 	let commentVoteStates: Map<number, 'up' | 'down'> = new Map();
 	let flaggedCommentIds: Set<number> = new Set();
@@ -26,6 +30,7 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 		comments,
 		commentVoteStates: Object.fromEntries(commentVoteStates),
 		flaggedCommentIds: Array.from(flaggedCommentIds),
-		page
+		page,
+		hasMore
 	};
 };

--- a/src/routes/highlights/+page.server.ts
+++ b/src/routes/highlights/+page.server.ts
@@ -1,0 +1,31 @@
+import type { PageServerLoad } from './$types';
+import { getDB, getBestComments, getCommentVoteStates, getFlaggedItemIds } from '$lib/server/db';
+
+export const load: PageServerLoad = async ({ url, platform, locals }) => {
+	const db = getDB(platform);
+	const page = parseInt(url.searchParams.get('p') || '1', 10);
+	const showdead = locals.user?.showdead === 1;
+	const comments = await getBestComments(db, {
+		// sinceMs を指定しない => 全期間
+		page,
+		limit: 30,
+		currentUserId: locals.user?.id,
+		showdead
+	});
+
+	let commentVoteStates: Map<number, 'up' | 'down'> = new Map();
+	let flaggedCommentIds: Set<number> = new Set();
+	if (locals.user) {
+		[commentVoteStates, flaggedCommentIds] = await Promise.all([
+			getCommentVoteStates(db, locals.user.id, comments.map((c) => c.id)),
+			getFlaggedItemIds(db, locals.user.id, comments.map((c) => c.id), 'comment')
+		]);
+	}
+
+	return {
+		comments,
+		commentVoteStates: Object.fromEntries(commentVoteStates),
+		flaggedCommentIds: Array.from(flaggedCommentIds),
+		page
+	};
+};

--- a/src/routes/highlights/+page.svelte
+++ b/src/routes/highlights/+page.svelte
@@ -35,7 +35,7 @@
 				[commentId]: result.voteState
 			};
 		} else if (res.status === 403) {
-			const result = await res.json();
+			const result = (await res.json()) as { error?: string };
 			alert(result.error || 'Permission denied');
 		}
 	}

--- a/src/routes/highlights/+page.svelte
+++ b/src/routes/highlights/+page.svelte
@@ -87,7 +87,7 @@
 	{/each}
 </div>
 
-{#if data.comments.length === 30}
+{#if data.hasMore}
 	<div class="more-link">
 		<a href="/highlights?p={data.page + 1}">More</a>
 	</div>

--- a/src/routes/highlights/+page.svelte
+++ b/src/routes/highlights/+page.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+	import { timeAgo, isNewUser } from '$lib/ranking';
+	import { formatText } from '$lib/format';
+
+	let { data } = $props();
+	let localVoteStates = $state<Record<number, 'up' | 'down' | null> | null>(null);
+	let localPoints = $state<Record<number, number>>({});
+
+	function getVoteState(commentId: number): 'up' | 'down' | null {
+		if (localVoteStates && commentId in localVoteStates) {
+			return localVoteStates[commentId];
+		}
+		return (data.commentVoteStates as Record<number, 'up' | 'down'>)[commentId] ?? null;
+	}
+
+	function getPoints(comment: { id: number; points: number }): number {
+		return localPoints[comment.id] ?? comment.points;
+	}
+
+	async function vote(commentId: number, direction: 'up' | 'down' = 'up') {
+		if (!data.user) {
+			window.location.href = '/login';
+			return;
+		}
+		const res = await fetch('/api/vote', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ itemId: commentId, itemType: 'comment', direction })
+		});
+		if (res.ok) {
+			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
+			localPoints = { ...localPoints, [commentId]: result.points };
+			localVoteStates = {
+				...(localVoteStates ?? {}),
+				[commentId]: result.voteState
+			};
+		} else if (res.status === 403) {
+			const result = await res.json();
+			alert(result.error || 'Permission denied');
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Highlights | ハッカーのろし</title>
+</svelte:head>
+
+<div style="padding-left: 40px;">
+	{#each data.comments as comment}
+		<div style="padding: 10px 0;">
+			<div class="comment-head">
+				<span class="comment-vote">
+					<button
+						class="upvote"
+						class:voted={getVoteState(comment.id) === 'up'}
+						onclick={() => vote(comment.id, 'up')}
+						aria-label="upvote comment"
+					>
+						&#9650;
+					</button>
+					{#if data.user && data.user.karma >= 500}
+						<button
+							class="downvote"
+							class:voted={getVoteState(comment.id) === 'down'}
+							onclick={() => vote(comment.id, 'down')}
+							aria-label="downvote comment"
+						>
+							&#9660;
+						</button>
+					{/if}
+				</span>
+				{getPoints(comment)} point{getPoints(comment) !== 1 ? 's' : ''} by
+				<a href="/user/{comment.username}" style={isNewUser(comment.user_created_at) ? 'color: #3c963c;' : ''}>{comment.username}</a>
+				<a href="/item/{comment.id}">{timeAgo(comment.created_at)}</a>
+				| <a href="/item/{comment.parent_id ?? comment.story_id}" style="color: #828282;">parent</a>
+				| <a href="/item/{comment.id}" style="color: #828282;">context</a>
+				| on: <a href="/item/{comment.story_id}">{comment.story_title}</a>
+			</div>
+			<div class="comment-text" class:faded={getPoints(comment) < 1} style="padding-left: 14px;">
+				{#each comment.text.split('\n') as paragraph}
+					{#if paragraph.trim()}
+						<p>{@html formatText(paragraph)}</p>
+					{/if}
+				{/each}
+			</div>
+		</div>
+	{/each}
+</div>
+
+{#if data.comments.length === 30}
+	<div class="more-link">
+		<a href="/highlights?p={data.page + 1}">More</a>
+	</div>
+{/if}

--- a/src/routes/leaders/+page.server.ts
+++ b/src/routes/leaders/+page.server.ts
@@ -4,7 +4,10 @@ import { getDB, getTopUsersByKarma } from '$lib/server/db';
 export const load: PageServerLoad = async ({ url, platform }) => {
 	const db = getDB(platform);
 	const page = parseInt(url.searchParams.get('p') || '1', 10);
-	const users = await getTopUsersByKarma(db, page, 30);
+	// hasMore 判定のため 1件多めに取る
+	const fetched = await getTopUsersByKarma(db, page, 31);
+	const hasMore = fetched.length > 30;
+	const users = fetched.slice(0, 30);
 
 	return {
 		users: users.map((u) => ({
@@ -12,6 +15,7 @@ export const load: PageServerLoad = async ({ url, platform }) => {
 			karma: u.karma,
 			created_at: u.created_at
 		})),
-		page
+		page,
+		hasMore
 	};
 };

--- a/src/routes/leaders/+page.server.ts
+++ b/src/routes/leaders/+page.server.ts
@@ -1,0 +1,17 @@
+import type { PageServerLoad } from './$types';
+import { getDB, getTopUsersByKarma } from '$lib/server/db';
+
+export const load: PageServerLoad = async ({ url, platform }) => {
+	const db = getDB(platform);
+	const page = parseInt(url.searchParams.get('p') || '1', 10);
+	const users = await getTopUsersByKarma(db, page, 30);
+
+	return {
+		users: users.map((u) => ({
+			username: u.username,
+			karma: u.karma,
+			created_at: u.created_at
+		})),
+		page
+	};
+};

--- a/src/routes/leaders/+page.svelte
+++ b/src/routes/leaders/+page.svelte
@@ -24,7 +24,7 @@
 	</table>
 </div>
 
-{#if data.users.length === 30}
+{#if data.hasMore}
 	<div class="more-link">
 		<a href="/leaders?p={data.page + 1}">More</a>
 	</div>

--- a/src/routes/leaders/+page.svelte
+++ b/src/routes/leaders/+page.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import { isNewUser } from '$lib/ranking';
+
+	let { data } = $props();
+</script>
+
+<svelte:head>
+	<title>Leaders | ハッカーのろし</title>
+</svelte:head>
+
+<div class="leaders-page">
+	<table>
+		<tbody>
+			{#each data.users as user, i}
+				<tr>
+					<td class="rank">{(data.page - 1) * 30 + i + 1}.</td>
+					<td class="user">
+						<a href="/user/{user.username}" style={isNewUser(user.created_at) ? 'color: #3c963c;' : ''}>{user.username}</a>
+					</td>
+					<td class="karma">{user.karma}</td>
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+</div>
+
+{#if data.users.length === 30}
+	<div class="more-link">
+		<a href="/leaders?p={data.page + 1}">More</a>
+	</div>
+{/if}
+
+<style>
+	.leaders-page {
+		padding: 8pt 0 8pt 30pt;
+		font-size: 10pt;
+	}
+
+	.leaders-page table {
+		border-spacing: 0;
+	}
+
+	.leaders-page td {
+		padding: 1pt 6pt 1pt 0;
+		vertical-align: top;
+	}
+
+	.leaders-page td.rank {
+		text-align: right;
+		color: #828282;
+	}
+
+	.leaders-page td.user a {
+		color: #000000;
+	}
+
+	.leaders-page td.karma {
+		color: #828282;
+	}
+</style>

--- a/src/routes/lists/+page.svelte
+++ b/src/routes/lists/+page.svelte
@@ -5,20 +5,48 @@
 			<td>指定した日のフロントページ投稿</td>
 		</tr>
 		<tr>
+			<td><a href="/highlights">highlights</a></td>
+			<td>全期間で最も支持されたコメント</td>
+		</tr>
+		<tr>
+			<td><a href="/shownew">shownew</a></td>
+			<td>新着の Show HN 投稿（時系列順）</td>
+		</tr>
+		<tr>
+			<td><a href="/asknew">asknew</a></td>
+			<td>新着の Ask HN 投稿（時系列順）</td>
+		</tr>
+		<tr>
 			<td><a href="/show">show</a></td>
-			<td>新着の Show HN 投稿</td>
+			<td>注目の Show HN 投稿</td>
 		</tr>
 		<tr>
 			<td><a href="/ask">ask</a></td>
-			<td>新着の Ask HN（テキスト）投稿</td>
+			<td>注目の Ask HN（テキスト）投稿</td>
 		</tr>
 		<tr>
 			<td><a href="/best">best</a></td>
 			<td>直近で最も支持された投稿</td>
 		</tr>
 		<tr>
+			<td><a href="/bestcomments">bestcomments</a></td>
+			<td>直近30日で最も支持されたコメント</td>
+		</tr>
+		<tr>
 			<td><a href="/active">active</a></td>
 			<td>最も活発に議論されているスレッド</td>
+		</tr>
+		<tr>
+			<td><a href="/noobstories">noobstories</a></td>
+			<td>新規ユーザーによる投稿</td>
+		</tr>
+		<tr>
+			<td><a href="/noobcomments">noobcomments</a></td>
+			<td>新規ユーザーによるコメント</td>
+		</tr>
+		<tr>
+			<td><a href="/leaders">leaders</a></td>
+			<td>karma の高いユーザー一覧</td>
 		</tr>
 		<tr>
 			<td><a href="/newcomments">newcomments</a></td>

--- a/src/routes/lists/+page.svelte
+++ b/src/routes/lists/+page.svelte
@@ -17,14 +17,6 @@
 			<td>新着の Ask HN 投稿（時系列順）</td>
 		</tr>
 		<tr>
-			<td><a href="/show">show</a></td>
-			<td>注目の Show HN 投稿</td>
-		</tr>
-		<tr>
-			<td><a href="/ask">ask</a></td>
-			<td>注目の Ask HN（テキスト）投稿</td>
-		</tr>
-		<tr>
 			<td><a href="/best">best</a></td>
 			<td>直近で最も支持された投稿</td>
 		</tr>
@@ -47,6 +39,14 @@
 		<tr>
 			<td><a href="/leaders">leaders</a></td>
 			<td>karma の高いユーザー一覧</td>
+		</tr>
+		<tr>
+			<td><a href="/show">show</a></td>
+			<td>注目の Show HN 投稿</td>
+		</tr>
+		<tr>
+			<td><a href="/ask">ask</a></td>
+			<td>注目の Ask HN（テキスト）投稿</td>
 		</tr>
 		<tr>
 			<td><a href="/newcomments">newcomments</a></td>

--- a/src/routes/noobcomments/+page.server.ts
+++ b/src/routes/noobcomments/+page.server.ts
@@ -1,0 +1,26 @@
+import type { PageServerLoad } from './$types';
+import { getDB, getCommentsByNewUsers, getCommentVoteStates, getFlaggedItemIds } from '$lib/server/db';
+import { TWO_WEEKS_MS } from '$lib/ranking';
+
+export const load: PageServerLoad = async ({ url, platform, locals }) => {
+	const db = getDB(platform);
+	const page = parseInt(url.searchParams.get('p') || '1', 10);
+	const showdead = locals.user?.showdead === 1;
+	const comments = await getCommentsByNewUsers(db, TWO_WEEKS_MS, page, 30, locals.user?.id, showdead);
+
+	let commentVoteStates: Map<number, 'up' | 'down'> = new Map();
+	let flaggedCommentIds: Set<number> = new Set();
+	if (locals.user) {
+		[commentVoteStates, flaggedCommentIds] = await Promise.all([
+			getCommentVoteStates(db, locals.user.id, comments.map((c) => c.id)),
+			getFlaggedItemIds(db, locals.user.id, comments.map((c) => c.id), 'comment')
+		]);
+	}
+
+	return {
+		comments,
+		commentVoteStates: Object.fromEntries(commentVoteStates),
+		flaggedCommentIds: Array.from(flaggedCommentIds),
+		page
+	};
+};

--- a/src/routes/noobcomments/+page.server.ts
+++ b/src/routes/noobcomments/+page.server.ts
@@ -6,7 +6,11 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 	const db = getDB(platform);
 	const page = parseInt(url.searchParams.get('p') || '1', 10);
 	const showdead = locals.user?.showdead === 1;
-	const comments = await getCommentsByNewUsers(db, TWO_WEEKS_MS, page, 30, locals.user?.id, showdead);
+	// 60件取得して delay フィルタ後にも 30件埋まる確率を上げ、hasMore を確実に判定する
+	let comments = await getCommentsByNewUsers(db, TWO_WEEKS_MS, page, 60, locals.user?.id, showdead);
+
+	const hasMore = comments.length > 30;
+	comments = comments.slice(0, 30);
 
 	let commentVoteStates: Map<number, 'up' | 'down'> = new Map();
 	let flaggedCommentIds: Set<number> = new Set();
@@ -21,6 +25,7 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 		comments,
 		commentVoteStates: Object.fromEntries(commentVoteStates),
 		flaggedCommentIds: Array.from(flaggedCommentIds),
-		page
+		page,
+		hasMore
 	};
 };

--- a/src/routes/noobcomments/+page.svelte
+++ b/src/routes/noobcomments/+page.svelte
@@ -35,7 +35,7 @@
 				[commentId]: result.voteState
 			};
 		} else if (res.status === 403) {
-			const result = await res.json();
+			const result = (await res.json()) as { error?: string };
 			alert(result.error || 'Permission denied');
 		}
 	}

--- a/src/routes/noobcomments/+page.svelte
+++ b/src/routes/noobcomments/+page.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+	import { timeAgo, isNewUser } from '$lib/ranking';
+	import { formatText } from '$lib/format';
+
+	let { data } = $props();
+	let localVoteStates = $state<Record<number, 'up' | 'down' | null> | null>(null);
+	let localPoints = $state<Record<number, number>>({});
+
+	function getVoteState(commentId: number): 'up' | 'down' | null {
+		if (localVoteStates && commentId in localVoteStates) {
+			return localVoteStates[commentId];
+		}
+		return (data.commentVoteStates as Record<number, 'up' | 'down'>)[commentId] ?? null;
+	}
+
+	function getPoints(comment: { id: number; points: number }): number {
+		return localPoints[comment.id] ?? comment.points;
+	}
+
+	async function vote(commentId: number, direction: 'up' | 'down' = 'up') {
+		if (!data.user) {
+			window.location.href = '/login';
+			return;
+		}
+		const res = await fetch('/api/vote', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ itemId: commentId, itemType: 'comment', direction })
+		});
+		if (res.ok) {
+			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
+			localPoints = { ...localPoints, [commentId]: result.points };
+			localVoteStates = {
+				...(localVoteStates ?? {}),
+				[commentId]: result.voteState
+			};
+		} else if (res.status === 403) {
+			const result = await res.json();
+			alert(result.error || 'Permission denied');
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Noob Comments | ハッカーのろし</title>
+</svelte:head>
+
+<div style="padding-left: 40px;">
+	{#each data.comments as comment}
+		<div style="padding: 10px 0;">
+			<div class="comment-head">
+				<span class="comment-vote">
+					<button
+						class="upvote"
+						class:voted={getVoteState(comment.id) === 'up'}
+						onclick={() => vote(comment.id, 'up')}
+						aria-label="upvote comment"
+					>
+						&#9650;
+					</button>
+					{#if data.user && data.user.karma >= 500}
+						<button
+							class="downvote"
+							class:voted={getVoteState(comment.id) === 'down'}
+							onclick={() => vote(comment.id, 'down')}
+							aria-label="downvote comment"
+						>
+							&#9660;
+						</button>
+					{/if}
+				</span>
+				<a href="/user/{comment.username}" style={isNewUser(comment.user_created_at) ? 'color: #3c963c;' : ''}>{comment.username}</a>
+				<a href="/item/{comment.id}">{timeAgo(comment.created_at)}</a>
+				| <a href="/item/{comment.parent_id ?? comment.story_id}" style="color: #828282;">parent</a>
+				| <a href="/item/{comment.id}" style="color: #828282;">context</a>
+				| on: <a href="/item/{comment.story_id}">{comment.story_title}</a>
+			</div>
+			<div class="comment-text" class:faded={getPoints(comment) < 1} style="padding-left: 14px;">
+				{#each comment.text.split('\n') as paragraph}
+					{#if paragraph.trim()}
+						<p>{@html formatText(paragraph)}</p>
+					{/if}
+				{/each}
+			</div>
+		</div>
+	{/each}
+</div>
+
+{#if data.comments.length === 30}
+	<div class="more-link">
+		<a href="/noobcomments?p={data.page + 1}">More</a>
+	</div>
+{/if}

--- a/src/routes/noobcomments/+page.svelte
+++ b/src/routes/noobcomments/+page.svelte
@@ -86,7 +86,7 @@
 	{/each}
 </div>
 
-{#if data.comments.length === 30}
+{#if data.hasMore}
 	<div class="more-link">
 		<a href="/noobcomments?p={data.page + 1}">More</a>
 	</div>

--- a/src/routes/noobstories/+page.server.ts
+++ b/src/routes/noobstories/+page.server.ts
@@ -6,6 +6,7 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 	const db = getDB(platform);
 	const page = parseInt(url.searchParams.get('p') || '1', 10);
 	const showdead = locals.user?.showdead === 1;
+	// 60件取得して hidden 除外後にも 30件埋まる確率を上げる
 	let stories = await getStoriesByNewUsers(db, TWO_WEEKS_MS, page, 60, showdead);
 
 	let votedIds: Set<number> = new Set();
@@ -17,12 +18,16 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 			getHiddenStoryIds(db, locals.user.id),
 			getFlaggedItemIds(db, locals.user.id, stories.map((s) => s.id), 'story')
 		]);
-		stories = stories.filter((s) => !hiddenIds.has(s.id)).slice(0, 30);
+		stories = stories.filter((s) => !hiddenIds.has(s.id));
 	}
+
+	const hasMore = stories.length > 30;
+	stories = stories.slice(0, 30);
 
 	return {
 		stories,
 		page,
+		hasMore,
 		votedIds: Array.from(votedIds),
 		flaggedIds: Array.from(flaggedIds)
 	};

--- a/src/routes/noobstories/+page.server.ts
+++ b/src/routes/noobstories/+page.server.ts
@@ -1,0 +1,29 @@
+import type { PageServerLoad } from './$types';
+import { getDB, getStoriesByNewUsers, getVotedStoryIds, getHiddenStoryIds, getFlaggedItemIds } from '$lib/server/db';
+import { TWO_WEEKS_MS } from '$lib/ranking';
+
+export const load: PageServerLoad = async ({ url, platform, locals }) => {
+	const db = getDB(platform);
+	const page = parseInt(url.searchParams.get('p') || '1', 10);
+	const showdead = locals.user?.showdead === 1;
+	let stories = await getStoriesByNewUsers(db, TWO_WEEKS_MS, page, 60, showdead);
+
+	let votedIds: Set<number> = new Set();
+	let hiddenIds: Set<number> = new Set();
+	let flaggedIds: Set<number> = new Set();
+	if (locals.user) {
+		[votedIds, hiddenIds, flaggedIds] = await Promise.all([
+			getVotedStoryIds(db, locals.user.id, stories.map((s) => s.id)),
+			getHiddenStoryIds(db, locals.user.id),
+			getFlaggedItemIds(db, locals.user.id, stories.map((s) => s.id), 'story')
+		]);
+		stories = stories.filter((s) => !hiddenIds.has(s.id)).slice(0, 30);
+	}
+
+	return {
+		stories,
+		page,
+		votedIds: Array.from(votedIds),
+		flaggedIds: Array.from(flaggedIds)
+	};
+};

--- a/src/routes/noobstories/+page.svelte
+++ b/src/routes/noobstories/+page.svelte
@@ -148,7 +148,7 @@
 	{/each}
 </div>
 
-{#if data.stories.length === 30}
+{#if data.hasMore}
 	<div class="more-link">
 		<a href="/noobstories?p={data.page + 1}">More</a>
 	</div>

--- a/src/routes/noobstories/+page.svelte
+++ b/src/routes/noobstories/+page.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+	import { FLAG_KARMA_THRESHOLD } from '$lib/constants';
+	import { timeAgo, extractDomain, isNewUser } from '$lib/ranking';
+
+	let { data } = $props();
+	let votedIds = $derived(new Set(data.votedIds));
+	let flaggedIds = $derived(new Set(data.flaggedIds ?? []));
+	let localVotedIds = $state<Set<number> | null>(null);
+	let localPoints = $state<Record<number, number>>({});
+	let localHiddenIds = $state<Set<number>>(new Set());
+	let localFlaggedIds = $state<Set<number> | null>(null);
+	let localFlagCounts = $state<Record<number, number>>({});
+
+	function getVotedIds(): Set<number> {
+		return localVotedIds ?? votedIds;
+	}
+
+	function getFlaggedIds(): Set<number> {
+		return localFlaggedIds ?? flaggedIds;
+	}
+
+	function getFlagCount(story: { id: number; flag_count?: number }): number {
+		return localFlagCounts[story.id] ?? story.flag_count ?? 0;
+	}
+
+	function getPoints(story: { id: number; points: number }): number {
+		return localPoints[story.id] ?? story.points;
+	}
+
+	function isHidden(id: number): boolean {
+		return localHiddenIds.has(id);
+	}
+
+	function canFlag(story: { user_id: number }): boolean {
+		return !!data.user && data.user.karma >= FLAG_KARMA_THRESHOLD && story.user_id !== data.user.id;
+	}
+
+	async function flag(storyId: number) {
+		if (!data.user) {
+			window.location.href = '/login';
+			return;
+		}
+		const res = await fetch('/api/flag', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
+		});
+		if (res.ok) {
+			const result: { flagged: boolean; flagCount: number } = await res.json();
+			const next = new Set(getFlaggedIds());
+			if (result.flagged) next.add(storyId);
+			else next.delete(storyId);
+			localFlaggedIds = next;
+			localFlagCounts = { ...localFlagCounts, [storyId]: result.flagCount };
+		} else if (res.status === 403) {
+			const result = (await res.json()) as { error?: string };
+			alert(result.error || 'Permission denied');
+		}
+	}
+
+	async function hide(storyId: number) {
+		const res = await fetch('/api/hide', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ storyId })
+		});
+		if (res.ok) {
+			const result: { hidden: boolean } = await res.json();
+			if (result.hidden) {
+				const next = new Set(localHiddenIds);
+				next.add(storyId);
+				localHiddenIds = next;
+			}
+		}
+	}
+
+	async function vote(storyId: number) {
+		if (!data.user) {
+			window.location.href = '/login';
+			return;
+		}
+		const res = await fetch('/api/vote', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
+		});
+		if (res.ok) {
+			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
+			localPoints = { ...localPoints, [storyId]: result.points };
+			const next = new Set(getVotedIds());
+			if (result.voteState === 'up') {
+				next.add(storyId);
+			} else {
+				next.delete(storyId);
+			}
+			localVotedIds = next;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Noob Stories | ハッカーのろし</title>
+</svelte:head>
+
+<div class="story-list">
+	{#each data.stories as story, i}
+		{#if !isHidden(story.id)}
+		<div class="story-item">
+			<span class="story-rank">{(data.page - 1) * 30 + i + 1}.</span>
+			<span class="story-vote">
+				<button
+					class="upvote"
+					class:voted={getVotedIds().has(story.id)}
+					onclick={() => vote(story.id)}
+					aria-label="upvote"
+				>
+					&#9650;
+				</button>
+			</span>
+			<div class="story-content" class:faded={story.dead === 1}>
+				<div class="story-title-line">
+					{#if story.url}
+						<a href={story.url} class="story-title">{story.title}</a>
+						<span class="story-domain">({extractDomain(story.url)})</span>
+					{:else}
+						<a href="/item/{story.id}" class="story-title">{story.title}</a>
+					{/if}
+					{#if getFlagCount(story) > 0} <span class="story-tag">[flagged]</span>{/if}
+					{#if story.dead === 1} <span class="story-tag">[dead]</span>{/if}
+				</div>
+				<div class="story-meta">
+					{getPoints(story)} point{getPoints(story) !== 1 ? 's' : ''} by
+					<a href="/user/{story.username}" style={isNewUser(story.user_created_at) ? 'color: #3c963c;' : ''}>{story.username}</a>
+					<a href="/item/{story.id}">{timeAgo(story.created_at)}</a> |
+					<a href="/item/{story.id}"
+						>{story.comment_count} comment{story.comment_count !== 1 ? 's' : ''}</a
+					>
+					{#if data.user}
+						| <a href="#hide" onclick={(e) => { e.preventDefault(); hide(story.id); }}>hide</a>
+					{/if}
+					{#if canFlag(story)}
+						| <a href="#flag" onclick={(e) => { e.preventDefault(); flag(story.id); }}>{getFlaggedIds().has(story.id) ? 'un-flag' : 'flag'}</a>
+					{/if}
+				</div>
+			</div>
+		</div>
+		{/if}
+	{/each}
+</div>
+
+{#if data.stories.length === 30}
+	<div class="more-link">
+		<a href="/noobstories?p={data.page + 1}">More</a>
+	</div>
+{/if}

--- a/src/routes/shownew/+page.server.ts
+++ b/src/routes/shownew/+page.server.ts
@@ -1,0 +1,28 @@
+import type { PageServerLoad } from './$types';
+import { getDB, getStories, getVotedStoryIds, getHiddenStoryIds, getFlaggedItemIds } from '$lib/server/db';
+
+export const load: PageServerLoad = async ({ url, platform, locals }) => {
+	const db = getDB(platform);
+	const page = parseInt(url.searchParams.get('p') || '1', 10);
+	const showdead = locals.user?.showdead === 1;
+	let stories = await getStories(db, { type: 'show', orderBy: 'newest', page, limit: 60, showdead });
+
+	let votedIds: Set<number> = new Set();
+	let hiddenIds: Set<number> = new Set();
+	let flaggedIds: Set<number> = new Set();
+	if (locals.user) {
+		[votedIds, hiddenIds, flaggedIds] = await Promise.all([
+			getVotedStoryIds(db, locals.user.id, stories.map((s) => s.id)),
+			getHiddenStoryIds(db, locals.user.id),
+			getFlaggedItemIds(db, locals.user.id, stories.map((s) => s.id), 'story')
+		]);
+		stories = stories.filter((s) => !hiddenIds.has(s.id)).slice(0, 30);
+	}
+
+	return {
+		stories,
+		page,
+		votedIds: Array.from(votedIds),
+		flaggedIds: Array.from(flaggedIds)
+	};
+};

--- a/src/routes/shownew/+page.server.ts
+++ b/src/routes/shownew/+page.server.ts
@@ -5,6 +5,7 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 	const db = getDB(platform);
 	const page = parseInt(url.searchParams.get('p') || '1', 10);
 	const showdead = locals.user?.showdead === 1;
+	// 60件取得して hidden 除外後にも 30件埋まる確率を上げる
 	let stories = await getStories(db, { type: 'show', orderBy: 'newest', page, limit: 60, showdead });
 
 	let votedIds: Set<number> = new Set();
@@ -16,12 +17,16 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 			getHiddenStoryIds(db, locals.user.id),
 			getFlaggedItemIds(db, locals.user.id, stories.map((s) => s.id), 'story')
 		]);
-		stories = stories.filter((s) => !hiddenIds.has(s.id)).slice(0, 30);
+		stories = stories.filter((s) => !hiddenIds.has(s.id));
 	}
+
+	const hasMore = stories.length > 30;
+	stories = stories.slice(0, 30);
 
 	return {
 		stories,
 		page,
+		hasMore,
 		votedIds: Array.from(votedIds),
 		flaggedIds: Array.from(flaggedIds)
 	};

--- a/src/routes/shownew/+page.svelte
+++ b/src/routes/shownew/+page.svelte
@@ -148,7 +148,7 @@
 	{/each}
 </div>
 
-{#if data.stories.length === 30}
+{#if data.hasMore}
 	<div class="more-link">
 		<a href="/shownew?p={data.page + 1}">More</a>
 	</div>

--- a/src/routes/shownew/+page.svelte
+++ b/src/routes/shownew/+page.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+	import { FLAG_KARMA_THRESHOLD } from '$lib/constants';
+	import { timeAgo, extractDomain, isNewUser } from '$lib/ranking';
+
+	let { data } = $props();
+	let votedIds = $derived(new Set(data.votedIds));
+	let flaggedIds = $derived(new Set(data.flaggedIds ?? []));
+	let localVotedIds = $state<Set<number> | null>(null);
+	let localPoints = $state<Record<number, number>>({});
+	let localHiddenIds = $state<Set<number>>(new Set());
+	let localFlaggedIds = $state<Set<number> | null>(null);
+	let localFlagCounts = $state<Record<number, number>>({});
+
+	function getVotedIds(): Set<number> {
+		return localVotedIds ?? votedIds;
+	}
+
+	function getFlaggedIds(): Set<number> {
+		return localFlaggedIds ?? flaggedIds;
+	}
+
+	function getFlagCount(story: { id: number; flag_count?: number }): number {
+		return localFlagCounts[story.id] ?? story.flag_count ?? 0;
+	}
+
+	function getPoints(story: { id: number; points: number }): number {
+		return localPoints[story.id] ?? story.points;
+	}
+
+	function isHidden(id: number): boolean {
+		return localHiddenIds.has(id);
+	}
+
+	function canFlag(story: { user_id: number }): boolean {
+		return !!data.user && data.user.karma >= FLAG_KARMA_THRESHOLD && story.user_id !== data.user.id;
+	}
+
+	async function flag(storyId: number) {
+		if (!data.user) {
+			window.location.href = '/login';
+			return;
+		}
+		const res = await fetch('/api/flag', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
+		});
+		if (res.ok) {
+			const result: { flagged: boolean; flagCount: number } = await res.json();
+			const next = new Set(getFlaggedIds());
+			if (result.flagged) next.add(storyId);
+			else next.delete(storyId);
+			localFlaggedIds = next;
+			localFlagCounts = { ...localFlagCounts, [storyId]: result.flagCount };
+		} else if (res.status === 403) {
+			const result = (await res.json()) as { error?: string };
+			alert(result.error || 'Permission denied');
+		}
+	}
+
+	async function hide(storyId: number) {
+		const res = await fetch('/api/hide', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ storyId })
+		});
+		if (res.ok) {
+			const result: { hidden: boolean } = await res.json();
+			if (result.hidden) {
+				const next = new Set(localHiddenIds);
+				next.add(storyId);
+				localHiddenIds = next;
+			}
+		}
+	}
+
+	async function vote(storyId: number) {
+		if (!data.user) {
+			window.location.href = '/login';
+			return;
+		}
+		const res = await fetch('/api/vote', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
+		});
+		if (res.ok) {
+			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
+			localPoints = { ...localPoints, [storyId]: result.points };
+			const next = new Set(getVotedIds());
+			if (result.voteState === 'up') {
+				next.add(storyId);
+			} else {
+				next.delete(storyId);
+			}
+			localVotedIds = next;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>New Show HN | ハッカーのろし</title>
+</svelte:head>
+
+<div class="story-list">
+	{#each data.stories as story, i}
+		{#if !isHidden(story.id)}
+		<div class="story-item">
+			<span class="story-rank">{(data.page - 1) * 30 + i + 1}.</span>
+			<span class="story-vote">
+				<button
+					class="upvote"
+					class:voted={getVotedIds().has(story.id)}
+					onclick={() => vote(story.id)}
+					aria-label="upvote"
+				>
+					&#9650;
+				</button>
+			</span>
+			<div class="story-content" class:faded={story.dead === 1}>
+				<div class="story-title-line">
+					{#if story.url}
+						<a href={story.url} class="story-title">{story.title}</a>
+						<span class="story-domain">({extractDomain(story.url)})</span>
+					{:else}
+						<a href="/item/{story.id}" class="story-title">{story.title}</a>
+					{/if}
+					{#if getFlagCount(story) > 0} <span class="story-tag">[flagged]</span>{/if}
+					{#if story.dead === 1} <span class="story-tag">[dead]</span>{/if}
+				</div>
+				<div class="story-meta">
+					{getPoints(story)} point{getPoints(story) !== 1 ? 's' : ''} by
+					<a href="/user/{story.username}" style={isNewUser(story.user_created_at) ? 'color: #3c963c;' : ''}>{story.username}</a>
+					<a href="/item/{story.id}">{timeAgo(story.created_at)}</a> |
+					<a href="/item/{story.id}"
+						>{story.comment_count} comment{story.comment_count !== 1 ? 's' : ''}</a
+					>
+					{#if data.user}
+						| <a href="#hide" onclick={(e) => { e.preventDefault(); hide(story.id); }}>hide</a>
+					{/if}
+					{#if canFlag(story)}
+						| <a href="#flag" onclick={(e) => { e.preventDefault(); flag(story.id); }}>{getFlaggedIds().has(story.id) ? 'un-flag' : 'flag'}</a>
+					{/if}
+				</div>
+			</div>
+		</div>
+		{/if}
+	{/each}
+</div>
+
+{#if data.stories.length === 30}
+	<div class="more-link">
+		<a href="/shownew?p={data.page + 1}">More</a>
+	</div>
+{/if}


### PR DESCRIPTION
## 関連 Issue
closes #68

## 結果

本家HN /lists 16項目のうち、当方は6項目しかなかったところを **13項目** に拡張。残り3項目はスキップ判断（理由は下記）。

### 実装した7ルート

| ルート | 内容 | 中核SQL |
|---|---|---|
| `/leaders` | karma 上位30ユーザーのリーダーボード | `SELECT users ORDER BY karma DESC LIMIT 30` |
| `/bestcomments` | 直近30日の高得点コメント上位30件 | `comments WHERE created_at>NOW-30d AND dead=0 ORDER BY points DESC` |
| `/highlights` | 全期間の高得点コメント上位30件 | `comments WHERE dead=0 ORDER BY points DESC` |
| `/shownew` | 新着 Show HN（ランク無視・新着順） | `getStories({type:'show', orderBy:'newest'})` |
| `/asknew` | 新着 Ask HN（ランク無視・新着順） | `getStories({type:'ask', orderBy:'newest'})` |
| `/noobstories` | 新規アカウント（直近14日）の投稿 | `stories JOIN users WHERE u.created_at>NOW-14d` |
| `/noobcomments` | 新規アカウントのコメント | `comments JOIN users WHERE u.created_at>NOW-14d` |

「新規アカウント」閾値は本家30日ではなく、`isNewUser()` のユーザー名緑表示と一貫させるため `TWO_WEEKS_MS`（14日）に揃えた。

### スキップ判断した6ルート

| ルート | スキップ理由 |
|---|---|
| `/pool` | モデレーター手動キュレーション前提。専用ツール必要 |
| `/invited` | 招待制スレッド機能が高度。需要不明 |
| `/classic` | 古参アカウント前提（HN 2007年以降）、当方は新興で意味なし |
| `/topcolors` | HN特有のお遊び機能 |
| `/whoishiring` | whoishiring 専用ユーザー未存在、運用前 |
| `/launches` | YC固有 |

`/lists` には載せない（404 防止）。将来運用が立ち上がってから個別 Issue で実装。

### `/lists` 更新

本家HN /lists 順序に合わせて 6項目→13項目に拡張:
front → highlights → shownew → asknew → show → ask → best → bestcomments → active → noobstories → noobcomments → leaders → newcomments

### 新設DB関数（src/lib/server/db.ts）

- `getTopUsersByKarma(db, page, limit)`
- `getBestComments(db, options: {sinceMs?, page, limit, showdead})`
- `getStoriesByNewUsers(db, sinceMs, page, limit, showdead)`
- `getCommentsByNewUsers(db, sinceMs, page, limit, showdead)`

### docs/architecture.md
- ルート一覧テーブルに新規7ルートを追加
- DB関数表を更新

## 変更統計
- 17 files changed, 1164 insertions(+), 3 deletions(-)
- 10 コミット（1ルート1コミット + lists + docs + 型修正）

## npm run check
- 開始: 8 errors, 3 warnings (既存)
- 完了: 8 errors, 3 warnings (新規エラーなし)

## Test plan
- [ ] /leaders で karma 順にユーザーが並ぶ
- [ ] /bestcomments で直近30日の高得点コメントが並ぶ
- [ ] /highlights で全期間の高得点コメントが並ぶ
- [ ] /shownew /asknew で新着順に並ぶ（/show /ask の rank 順との差異を確認）
- [ ] /noobstories /noobcomments で14日以内に作成されたアカウントの投稿/コメントが並ぶ
- [ ] /lists に13項目が本家HN順で並ぶ
- [ ] スキップ6ルート (/pool /invited /classic /topcolors /whoishiring /launches) は404 になる（意図通り）