### PR TITLE
fix: #73 スマホ監査で /lists /leaders 差分修正（部分対応）

### DIFF
--- a/src/routes/leaders/+page.svelte
+++ b/src/routes/leaders/+page.svelte
@@ -10,6 +10,13 @@
 
 <div class="leaders-page">
 	<table>
+		<thead>
+			<tr>
+				<td></td>
+				<td></td>
+				<td class="karma-header">total</td>
+			</tr>
+		</thead>
 		<tbody>
 			{#each data.users as user, i}
 				<tr>
@@ -32,8 +39,14 @@
 
 <style>
 	.leaders-page {
-		padding: 8pt 0 8pt 30pt;
+		padding: 8pt 0 8pt 10pt;
 		font-size: 10pt;
+	}
+
+	.leaders-page td.karma-header {
+		color: #828282;
+		text-align: right;
+		padding-bottom: 4pt;
 	}
 
 	.leaders-page table {

--- a/src/routes/lists/+page.svelte
+++ b/src/routes/lists/+page.svelte
@@ -57,7 +57,7 @@
 
 <style>
 	.lists-page {
-		padding: 8pt 0 8pt 30pt;
+		padding: 8pt 0 8pt 10pt;
 		font-size: 10pt;
 	}
 


### PR DESCRIPTION
## 関連 Issue
refs #73

## 監査範囲

セッション316で Playwright MCP を 375×812 で起動し、以下を本家HN ↔ 当方で並べて目視確認:

| ページ | 結果 |
|---|---|
| `/` (front) | 概ね一致。本家には各行に `hide` リンクあるが当方なし → 別Issue化 |
| `/item/[id]` | 浅いネスト範囲では一致 |
| `/lists` | **差分あり → 本PRで修正** |
| `/leaders` | **差分あり → 本PRで修正** |

確認途中で Chrome ロック衝突（session315 と同じ症状、sandbox が `kill` 系を deny）が発生し、以降のページは視覚確認できず。

## 修正内容

### /lists
- 左パディング `8pt 0 8pt 30pt` → `8pt 0 8pt 10pt`（本家HN準拠、~10px相当）

### /leaders
- `<thead>` に `total` 列ヘッダ追加（本家HNにあり当方欠落）
- 左パディング `8pt 0 8pt 30pt` → `8pt 0 8pt 10pt`

## 残作業（#73 続き）

以下のページは視覚確認できず、Chrome ロックが解消した次セッションで実施:

- `/newest` `/ask` `/show` `/best` `/active` `/newcomments`
- `/shownew` `/asknew` `/bestcomments` `/highlights` `/noobstories` `/noobcomments`
- `/front?day=` `/faq` `/guidelines` `/showhn` `/user` `/submit` `/signup`
- `/from`

これらは `.story-list` / `.comment-list` / `.story-item` 等の共通CSSを使うので /front 動作確認の延長で大半は問題ないと推定されるが、視覚的に未確認。

## スクショ素材
freeza/hn-audit-mobile-r2/ に保存:
- local-front.png / hn-front.png
- local-item.png
- local-lists.png / hn-lists.png
- local-leaders.png / hn-leaders.png

## 別Issue化
- 一覧 (`/` `/newest` `/best` 等) の story 行に `| hide` リンクを追加（本家準拠、PC + mobile 共通の差分） — 別Issue 起票予定

## Test plan
- [ ] /lists で左パディングが詰まり、本家HN相当の見た目に
- [ ] /leaders で "total" ヘッダが karma 列の上に表示される
- [ ] PC でも視覚崩れがない