### PR TITLE
fix: admin/ipban の <table> 直下 <tr> を <tbody> でラップ (#103)

### DIFF
--- a/src/routes/admin/ipban/+page.svelte
+++ b/src/routes/admin/ipban/+page.svelte
@@ -22,30 +22,32 @@
 	<!-- SvelteKit form action は同一オリジンチェック付き -->
 	<form method="POST" action="?/ban">
 		<table style="border-collapse: collapse;">
-			<tr>
-				<td style="padding: 4pt 8pt 4pt 0;">IP:</td>
-				<td style="padding: 4pt 0;">
-					<input type="text" name="ip" value={form?.ip ?? ''} size="20" style="font-family: Verdana, Geneva, sans-serif; font-size: 10pt;" />
-				</td>
-			</tr>
-			<tr>
-				<td style="padding: 4pt 8pt 4pt 0;">理由:</td>
-				<td style="padding: 4pt 0;">
-					<input type="text" name="reason" value={form?.reason ?? ''} size="40" maxlength="1024" style="font-family: Verdana, Geneva, sans-serif; font-size: 10pt;" />
-				</td>
-			</tr>
-			<tr>
-				<td style="padding: 4pt 8pt 4pt 0;">有効期限 (時間):</td>
-				<td style="padding: 4pt 0;">
-					<input type="text" name="expiresIn" value={form?.expiresInRaw ?? ''} size="6" style="font-family: Verdana, Geneva, sans-serif; font-size: 10pt;" />
-					<span style="margin-left: 8pt;">空欄で無期限</span>
-				</td>
-			</tr>
-			<tr>
-				<td colspan="2" style="padding: 8pt 0;">
-					<button type="submit" style="font-family: Verdana, Geneva, sans-serif; font-size: 10pt;">ban する</button>
-				</td>
-			</tr>
+			<tbody>
+				<tr>
+					<td style="padding: 4pt 8pt 4pt 0;">IP:</td>
+					<td style="padding: 4pt 0;">
+						<input type="text" name="ip" value={form?.ip ?? ''} size="20" style="font-family: Verdana, Geneva, sans-serif; font-size: 10pt;" />
+					</td>
+				</tr>
+				<tr>
+					<td style="padding: 4pt 8pt 4pt 0;">理由:</td>
+					<td style="padding: 4pt 0;">
+						<input type="text" name="reason" value={form?.reason ?? ''} size="40" maxlength="1024" style="font-family: Verdana, Geneva, sans-serif; font-size: 10pt;" />
+					</td>
+				</tr>
+				<tr>
+					<td style="padding: 4pt 8pt 4pt 0;">有効期限 (時間):</td>
+					<td style="padding: 4pt 0;">
+						<input type="text" name="expiresIn" value={form?.expiresInRaw ?? ''} size="6" style="font-family: Verdana, Geneva, sans-serif; font-size: 10pt;" />
+						<span style="margin-left: 8pt;">空欄で無期限</span>
+					</td>
+				</tr>
+				<tr>
+					<td colspan="2" style="padding: 8pt 0;">
+						<button type="submit" style="font-family: Verdana, Geneva, sans-serif; font-size: 10pt;">ban する</button>
+					</td>
+				</tr>
+			</tbody>
 		</table>
 	</form>
 


### PR DESCRIPTION
## 関連 Issue
closes #103

## 背景
PR #102 (#91 セルフ unban) の検証中に発覚。`npm run build` が `src/routes/admin/ipban/+page.svelte:25` の `<table>` 直下の `<tr>` で失敗していた。

## 変更内容
- 1 つ目の `<table>`（新規 ban フォーム）の中の `<tr>` 群を `<tbody>` でラップ
- 2 つ目の `<table>`（active な ban 一覧）は元から `<thead>` / `<tbody>` 構造で問題なし

## 検証
- `npm run build` 通過
- `npx svelte-check` で当該エラーが消えたことを確認
- 見た目の変更なし

## 関連
- #91 (セルフ unban、検証中に発覚)
- #77 (admin/ipban 元実装)