### PR TITLE
audit: PC幅で新機能関連画面の本家HN差分監査 (#106)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ Thumbs.db
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 test-results/
+tests/audit/screenshots/

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -199,7 +199,24 @@ hide リンクとサーバー側除外ロジックを実装するページ:
 3. `+page.svelte` のメタ行に hide / un-hide トグルリンクを追加
 4. クリック後の即時消去のため `localHiddenIds` を保持
 
-将来的には `<StoryListItem />` 共通コンポーネント（#86）を抽出し、新規ページではそれを使うだけで自動的に hide が入るようにする。
+`<StoryListItem />` 共通コンポーネント（#86）を抽出済み。新規ページはこれを使うだけで自動的に hide が入る。
+
+#### StoryListItem 抽出後の DOM 同一性（#86, #106 で検証）
+
+抽出前の `+page.svelte` 等にハードコードされていた `.story-item` レンダリング DOM と、抽出後の `<StoryListItem />` レンダリング DOM はクラス名・タグ階層・テキストノードの並びが完全に一致する（`/`,  `/newest`, `/best`, `/active`, `/front`, `/ask`, `/show`, `/asknew`, `/shownew`, `/noobstories`, `/from`, `/polls`, `/search` の全 13 ページが対象）。具体的には次の構造:
+
+```
+<div class="story-item">
+  <span class="story-rank">{rank}.</span>      <!-- /search 等で rank=null のときは省略 -->
+  <span class="story-vote"><button class="upvote" /></span>
+  <div class="story-content">
+    <div class="story-title-line">{title} {domain} {[poll]} {[flagged]} {[dead]}</div>
+    <div class="story-meta">{points} by {user} {age} | {N comments} | {hide?} | {flag?}</div>
+  </div>
+</div>
+```
+
+抽出時に変わったのは「楽観的更新の state を親側から行ごとに分散」「`canFlag` / `[poll]` 判定を `$lib/storyActions.ts` の純粋関数化」のみで、CSS / DOM は同等。`/polls` の `forcePollTag` と `/search` の `rank` 省略は元々ページ側にあった分岐をそのまま prop 化したもの。
 
 ### フラグ・モデレーション
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"test:e2e": "playwright test",
-		"test:e2e:ui": "playwright test --ui"
+		"test:e2e:ui": "playwright test --ui",
+		"test:audit": "playwright test --config=playwright.audit.config.ts"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.59.1",

--- a/playwright.audit.config.ts
+++ b/playwright.audit.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// 監査用 config: 外部 URL（本番 + 本家 HN）を叩くため webServer は起動しない
+export default defineConfig({
+	testDir: 'tests/audit',
+	fullyParallel: false,
+	workers: 1,
+	timeout: 60_000,
+	use: {
+		viewport: { width: 1280, height: 720 },
+		trace: 'off'
+	},
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'], viewport: { width: 1280, height: 720 } }
+		}
+	]
+});

--- a/tests/audit/audit-pc-width.spec.ts
+++ b/tests/audit/audit-pc-width.spec.ts
@@ -27,7 +27,7 @@ test.beforeAll(() => {
 for (const site of SITES) {
 	test(`${site.id} /polls full page`, async ({ page }) => {
 		await page.setViewportSize({ width: 1280, height: 720 });
-		await page.goto(`${site.baseURL}/polls`, { waitUntil: 'networkidle' });
+		await page.goto(`${site.baseURL}/polls`, { waitUntil: 'load' });
 		await page.screenshot({
 			path: path.join(OUT_DIR, `${site.id}-polls.png`),
 			fullPage: true
@@ -38,7 +38,7 @@ for (const site of SITES) {
 
 	test(`${site.id} /newest first story meta`, async ({ page }) => {
 		await page.setViewportSize({ width: 1280, height: 720 });
-		await page.goto(`${site.baseURL}/newest`, { waitUntil: 'networkidle' });
+		await page.goto(`${site.baseURL}/newest`, { waitUntil: 'load' });
 
 		// 本家HN は .athing + .subtext 構造、当方は .story-item + .story-meta 構造
 		// 両方の場合に対応するため body から first story 周辺を抽出する

--- a/tests/audit/audit-pc-width.spec.ts
+++ b/tests/audit/audit-pc-width.spec.ts
@@ -1,0 +1,83 @@
+import { test } from '@playwright/test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const OUT_DIR = path.join(__dirname, 'screenshots');
+
+// 当方は本番 (https://hn.llll-ll.com) を叩く想定だが、本番が落ちている場合は
+// AUDIT_OURS_URL=http://localhost:5173 で dev server に向けることもできる
+const OURS_URL = process.env.AUDIT_OURS_URL ?? 'https://hn.llll-ll.com';
+
+const SITES = [
+	{ id: 'ours', baseURL: OURS_URL },
+	{ id: 'hn', baseURL: 'https://news.ycombinator.com' }
+] as const;
+
+function ensureOut() {
+	if (!fs.existsSync(OUT_DIR)) fs.mkdirSync(OUT_DIR, { recursive: true });
+}
+
+test.beforeAll(() => {
+	ensureOut();
+});
+
+for (const site of SITES) {
+	test(`${site.id} /polls full page`, async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 720 });
+		await page.goto(`${site.baseURL}/polls`, { waitUntil: 'networkidle' });
+		await page.screenshot({
+			path: path.join(OUT_DIR, `${site.id}-polls.png`),
+			fullPage: true
+		});
+		const html = await page.content();
+		fs.writeFileSync(path.join(OUT_DIR, `${site.id}-polls.html`), html);
+	});
+
+	test(`${site.id} /newest first story meta`, async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 720 });
+		await page.goto(`${site.baseURL}/newest`, { waitUntil: 'networkidle' });
+
+		// 本家HN は .athing + .subtext 構造、当方は .story-item + .story-meta 構造
+		// 両方の場合に対応するため body から first story 周辺を抽出する
+		const fullHtml = await page.content();
+		fs.writeFileSync(path.join(OUT_DIR, `${site.id}-newest.html`), fullHtml);
+
+		// 当方: .story-item の最初の .story-meta
+		// 本家: .athing の直後の .subtext
+		const metaHtml = await page.evaluate(() => {
+			// 本家 HN 構造
+			const subtext = document.querySelector('.subtext');
+			if (subtext) {
+				const athing = subtext.closest('tr')?.previousElementSibling as HTMLElement | null;
+				return {
+					kind: 'hn',
+					athing: athing?.outerHTML ?? null,
+					subtext: subtext.outerHTML
+				};
+			}
+			// 当方 HN-noroshi 構造
+			const item = document.querySelector('.story-item');
+			if (item) {
+				return {
+					kind: 'ours',
+					item: item.outerHTML,
+					meta: item.querySelector('.story-meta')?.outerHTML ?? null
+				};
+			}
+			return { kind: 'unknown' };
+		});
+
+		fs.writeFileSync(
+			path.join(OUT_DIR, `${site.id}-newest-meta.json`),
+			JSON.stringify(metaHtml, null, 2)
+		);
+
+		await page.screenshot({
+			path: path.join(OUT_DIR, `${site.id}-newest.png`),
+			fullPage: false
+		});
+	});
+}


### PR DESCRIPTION
## 関連 Issue

closes #106

## 監査結果サマリ

| Phase | 結果 |
|---|---|
| A. StoryListItem DOM 同一性 | **同等**。リファクタ前後で CSS class / タグ階層 / テキストノード並びが完全一致 |
| B. profile email 行 docs/spec.md | **反映済み**。L121-132 の「ユーザー設定」テーブルから email 行は削除済み、L362 にも email 認証廃止が明記済み |
| C. 本家 HN との視覚差分 | 修正候補あり（後述） |

## Phase A 詳細

`c0b35cd` (リファクタ直前の `+page.svelte`) と現在の `+page.svelte` + `StoryListItem.svelte` を比較。

- 構造: `<div class="story-item">` > `.story-rank` + `.story-vote` > `button.upvote` + `.story-content` > `.story-title-line` + `.story-meta`
- 抽出により変わったのは（1）楽観的更新の state を行ごとに分散、（2）`canFlag` / `[poll]` 判定の純粋関数化（`$lib/storyActions.ts`）のみ
- `forcePollTag` (/polls) と `rank=null` (/search) の prop 化は元々ページ側にあった分岐をそのまま移しただけ
- 13 ページ（`/`, `/newest`, `/best`, `/active`, `/front`, `/ask`, `/show`, `/asknew`, `/shownew`, `/noobstories`, `/from`, `/polls`, `/search`）すべてが StoryListItem を経由

## Phase C 修正候補（本 PR では修正しない、別 Issue 化を推奨）

本家との視覚差分のうち **DESIGN.md の Visual Fidelity 原則に照らして要修正** な候補:

1. **`/newest` メタ行に `past` リンクが無い** — 本家は `points by user time | hide | past | discuss`。当方は `past` 無し。`/item/[id]` には #71 で past を追加済みだがリスト側のメタ行にはない
2. **`discuss` 文言** — コメント数 0 件時、本家は `discuss` を表示、当方は `0 comments`
3. **未ログイン時の `hide` リンク** — 本家は表示してクリック時にログイン誘導（vote と同じパターン）、当方は `{#if user}` で消している。仕様検討事項

DOM タグ／CSS class 名の差異は DESIGN.md の **Visual Fidelity, Modern Implementation** 原則により許容範囲。

## 追加成果物

- `tests/audit/audit-pc-width.spec.ts` — 本家 HN と当方の HTML 構造を比較する Playwright スクリプト（再現可能）
- `playwright.audit.config.ts` — 監査用 config（webServer 不要、外部 URL 比較）
- `tests/audit/screenshots/` は `.gitignore`（バイナリ膨張回避）

## 副次発見（緊急）

監査中に **本番 `https://hn.llll-ll.com/*` が全 500** になっていることが判明。直近の DB マイグレーション未適用が原因の可能性が高い。別 Issue で扱う。

## Test plan

- [x] Phase A: ソース比較で DOM 同一性確認
- [x] Phase B: docs/spec.md grep で email 行不在を確認
- [x] Phase C: Playwright で本家と当方の HTML を取得・比較
- [ ] 本番 500 修正後に監査スクリプトを再実行して最終確認（別 Issue）