### PR TITLE
fix: 本番 D1 マイグレーション未適用による全 500 を復旧 (#109)

### DIFF
--- a/db/migrations/2026-05-recovery.sql
+++ b/db/migrations/2026-05-recovery.sql
@@ -1,0 +1,77 @@
+-- 2026-05-06 本番復旧マイグレーション (#109)
+--
+-- 直近の機能追加 (#76 アカウント削除 / #77 IP ban / #88 username 変更 /
+-- #74 poll / #92 自動 ban / #18 hide / favorites) で db/schema.sql は拡張されたが
+-- 本番 D1 への適用が抜けており、`getStories` クエリ等が「no such column / table」で
+-- 全 500 になっていた。本ファイルを冪等に流すと復旧する。
+--
+-- 適用方法:
+--   wrangler d1 execute hacker-noroshi-db --remote --file=db/migrations/2026-05-recovery.sql
+--
+-- ALTER TABLE ADD COLUMN は冪等ではない（既存だとエラー）。本ファイルは未適用環境を
+-- 想定している。一部適用済みで再実行する場合は、エラーを無視するか個別 SQL を抜粋して流す。
+
+-- ============================================================
+-- Tier 1: users カラム追加（500 直接の主犯）
+-- ============================================================
+
+ALTER TABLE users ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE users ADD COLUMN deleted_at TEXT;
+ALTER TABLE users ADD COLUMN is_admin INTEGER NOT NULL DEFAULT 0;
+
+-- ============================================================
+-- Tier 2: 不足テーブル（CREATE TABLE IF NOT EXISTS で冪等）
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS favorites (
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  story_id INTEGER NOT NULL REFERENCES stories(id),
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+  PRIMARY KEY (user_id, story_id)
+);
+CREATE INDEX IF NOT EXISTS idx_favorites_user_id ON favorites(user_id);
+
+CREATE TABLE IF NOT EXISTS hidden (
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  story_id INTEGER NOT NULL REFERENCES stories(id),
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+  PRIMARY KEY (user_id, story_id)
+);
+CREATE INDEX IF NOT EXISTS idx_hidden_user_id ON hidden(user_id);
+
+CREATE TABLE IF NOT EXISTS username_history (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  old_username TEXT NOT NULL,
+  new_username TEXT NOT NULL,
+  changed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+CREATE INDEX IF NOT EXISTS idx_username_history_old ON username_history(old_username);
+CREATE INDEX IF NOT EXISTS idx_username_history_user ON username_history(user_id);
+
+CREATE TABLE IF NOT EXISTS ip_bans (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ip TEXT NOT NULL,
+  reason TEXT NOT NULL DEFAULT '',
+  banned_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+  expires_at TEXT,
+  banned_by INTEGER REFERENCES users(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_ip_bans_ip ON ip_bans(ip);
+CREATE INDEX IF NOT EXISTS idx_ip_bans_expires ON ip_bans(expires_at);
+
+CREATE TABLE IF NOT EXISTS ip_login_failures (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ip TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+CREATE INDEX IF NOT EXISTS idx_ip_login_failures_ip_created ON ip_login_failures(ip, created_at);
+
+CREATE TABLE IF NOT EXISTS poll_options (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  story_id INTEGER NOT NULL REFERENCES stories(id) ON DELETE CASCADE,
+  text TEXT NOT NULL,
+  position INTEGER NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+CREATE INDEX IF NOT EXISTS idx_poll_options_story ON poll_options(story_id);

--- a/db/migrations/2026-05-recovery.sql
+++ b/db/migrations/2026-05-recovery.sql
@@ -1,15 +1,20 @@
--- 2026-05-06 本番復旧マイグレーション (#109)
+-- 2026-05-recovery.sql — 本番復旧マイグレーション (#109)
+--
+-- ステータス: 本番 (hacker-noroshi-db --remote) には 2026-05-06 適用済み。
+-- 再実行は不要。本ファイルは記録目的で git に残し、新規 D1 セットアップや
+-- 同種事故の再発時に未適用分を手早く流すための雛形として使う。
 --
 -- 直近の機能追加 (#76 アカウント削除 / #77 IP ban / #88 username 変更 /
 -- #74 poll / #92 自動 ban / #18 hide / favorites) で db/schema.sql は拡張されたが
 -- 本番 D1 への適用が抜けており、`getStories` クエリ等が「no such column / table」で
 -- 全 500 になっていた。本ファイルを冪等に流すと復旧する。
 --
--- 適用方法:
+-- 適用方法（未適用環境向け）:
 --   wrangler d1 execute hacker-noroshi-db --remote --file=db/migrations/2026-05-recovery.sql
 --
--- ALTER TABLE ADD COLUMN は冪等ではない（既存だとエラー）。本ファイルは未適用環境を
--- 想定している。一部適用済みで再実行する場合は、エラーを無視するか個別 SQL を抜粋して流す。
+-- 注意: Tier 1 の ALTER TABLE ADD COLUMN は冪等ではない（既存カラムだとエラー）。
+-- 一部適用済みで再実行する場合は、Tier 1 の 3 行を個別 SQL で抜粋して流すか、
+-- 「duplicate column」エラーを無視して進める。Tier 2 は CREATE ... IF NOT EXISTS で冪等。
 
 -- ============================================================
 -- Tier 1: users カラム追加（500 直接の主犯）

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -56,6 +56,16 @@ D1 データベース ID: `185871af-76c3-403c-81c8-aede8f8cd100`
 
 D1 にはマイグレーション機構が無いので、`db/schema.sql` を編集した後、変更分の SQL を直接適用する。
 
+スキーマ変更を伴う PR は `db/migrations/<日付>-<topic>.sql` を併せて追加し、`docs/operations.md` の本セクションにコマンド単位で記録する。複数のマイグレーションが未適用のまま積み上がった場合の一括復旧は `db/migrations/2026-05-recovery.sql` を参照。
+
+### 一括復旧（2026-05-06 適用 / #109）
+
+直近の機能追加 (#76 / #77 / #88 / #74 / #92 / #18 / favorites) で本番 D1 に未適用の DDL が積み上がり、`SELECT u.deleted as user_deleted` 等で全 500 になっていた。下記コマンドで一括復旧する（冪等な部分のみ。`ALTER TABLE ADD COLUMN` は未適用環境向け）。
+
+```bash
+wrangler d1 execute hacker-noroshi-db --remote --file=db/migrations/2026-05-recovery.sql
+```
+
 ### #17 フラグ・モデレーション（2026-04 適用）
 
 ```bash


### PR DESCRIPTION
## 関連 Issue

closes #109

## 状況

本番 \`https://hn.llll-ll.com/*\` が全 500 だった（2026-05-06 検出）。直近の機能追加 (#76 / #77 / #88 / #74 / #92 / #18 / favorites) で \`db/schema.sql\` は拡張されたが、本番 D1 への適用が抜けていたため。

## 直接の主犯

\`getStories\` クエリの \`SELECT u.deleted as user_deleted\` が、本番 \`users\` テーブルに \`deleted\` カラムが無いため未ログインでも全失敗していた。

## 適用した変更（本番 D1 に直接適用済み）

### Tier 1: users カラム追加
- \`deleted\` INTEGER NOT NULL DEFAULT 0 (#76)
- \`deleted_at\` TEXT (#76)
- \`is_admin\` INTEGER NOT NULL DEFAULT 0 (#77)

→ Tier 1 適用直後に \`/\`, \`/newest\`, \`/best\`, \`/ask\`, \`/show\` が 200 復帰

### Tier 2: 不足テーブル
- \`favorites\` (+ index)
- \`hidden\` (+ index) (#18)
- \`username_history\` (+ 2 indexes) (#88)
- \`ip_bans\` (+ 2 indexes) (#77)
- \`ip_login_failures\` (+ index) (#92)
- \`poll_options\` (+ index) (#74)

→ Tier 2 適用後に \`/polls\`, \`/login\`, \`/ipban\` も 200 確認

## 本 PR で git に残すもの

- \`db/migrations/2026-05-recovery.sql\` — 冪等な復旧スクリプト（未適用環境を再現する場合に使える）
- \`docs/operations.md\` — 一括復旧コマンドの追記、および今後 schema 変更 PR は \`db/migrations/\` に併せて追加するルールの明示

## 副次（本 PR 範囲外、後追い）

- \`users.email\` カラムは本番にまだ存在（#90 で local schema 削除済み、SELECT 不参照のため 500 主犯ではなかった）
- \`stories.type\` の CHECK 制約に \`'poll'\` 未追加。SELECT は通るが新規 poll 投稿時に失敗。テーブル再作成パターンが必要（docs/operations.md L150 以降記載）
- Turnstile secret 設定（/ipban セルフ unban のみ、本タスク外）

## Test plan

- [x] Tier 1 適用直後に \`/\` 等が 200 を返すこと確認済み
- [x] Tier 2 適用後に \`/polls\`, \`/login\`, \`/ipban\` が 200 を返すこと確認済み
- [x] \`PRAGMA table_info(users)\` で 3 カラムが追加されていることを確認
- [x] \`SELECT name FROM sqlite_master WHERE type='table'\` で6テーブルが作成されていることを確認
- [ ] ログイン後の hide / favorite / poll 投稿は v1 リリース前に手動 e2e で確認推奨（#105）