### PR TITLE
audit: 独自画面の DESIGN.md 準拠監査・修正 (#107)

### DIFF
--- a/src/routes/admin/ipban/+page.svelte
+++ b/src/routes/admin/ipban/+page.svelte
@@ -15,7 +15,7 @@
 		<p style="color: #ff0000;">{form.error}</p>
 	{/if}
 	{#if form?.success}
-		<p style="color: #828282;">処理しました。</p>
+		<p>処理しました。</p>
 	{/if}
 
 	<p><b>新規 ban</b></p>
@@ -26,19 +26,19 @@
 				<tr>
 					<td>IP:</td>
 					<td>
-						<input type="text" name="ip" value={form?.ip ?? ''} size="20" />
+						<input type="text" name="ip" value={form?.ip ?? ''} />
 					</td>
 				</tr>
 				<tr>
 					<td>理由:</td>
 					<td>
-						<input type="text" name="reason" value={form?.reason ?? ''} size="40" maxlength="1024" />
+						<input type="text" name="reason" value={form?.reason ?? ''} maxlength="1024" />
 					</td>
 				</tr>
 				<tr>
 					<td>有効期限 (時間):</td>
 					<td>
-						<input type="text" name="expiresIn" value={form?.expiresInRaw ?? ''} size="6" />
+						<input type="text" name="expiresIn" value={form?.expiresInRaw ?? ''} />
 						<span> 空欄で無期限</span>
 					</td>
 				</tr>

--- a/src/routes/admin/ipban/+page.svelte
+++ b/src/routes/admin/ipban/+page.svelte
@@ -6,45 +6,46 @@
 	<title>admin / IP ban | ハッカーのろし</title>
 </svelte:head>
 
-<div style="padding: 20pt; font-family: Verdana, Geneva, sans-serif; font-size: 10pt; color: #000000;">
+<div class="hn-form">
 	<p><b>IP ban 管理</b></p>
 
 	{#if form?.banError}
-		<p style="color: #cc0000;">{form.banError}</p>
+		<p style="color: #ff0000;">{form.banError}</p>
 	{:else if form?.error}
-		<p style="color: #cc0000;">{form.error}</p>
+		<p style="color: #ff0000;">{form.error}</p>
 	{/if}
 	{#if form?.success}
-		<p style="color: #008800;">処理しました。</p>
+		<p style="color: #828282;">処理しました。</p>
 	{/if}
 
 	<p><b>新規 ban</b></p>
 	<!-- SvelteKit form action は同一オリジンチェック付き -->
 	<form method="POST" action="?/ban">
-		<table style="border-collapse: collapse;">
+		<table>
 			<tbody>
 				<tr>
-					<td style="padding: 4pt 8pt 4pt 0;">IP:</td>
-					<td style="padding: 4pt 0;">
-						<input type="text" name="ip" value={form?.ip ?? ''} size="20" style="font-family: Verdana, Geneva, sans-serif; font-size: 10pt;" />
+					<td>IP:</td>
+					<td>
+						<input type="text" name="ip" value={form?.ip ?? ''} size="20" />
 					</td>
 				</tr>
 				<tr>
-					<td style="padding: 4pt 8pt 4pt 0;">理由:</td>
-					<td style="padding: 4pt 0;">
-						<input type="text" name="reason" value={form?.reason ?? ''} size="40" maxlength="1024" style="font-family: Verdana, Geneva, sans-serif; font-size: 10pt;" />
+					<td>理由:</td>
+					<td>
+						<input type="text" name="reason" value={form?.reason ?? ''} size="40" maxlength="1024" />
 					</td>
 				</tr>
 				<tr>
-					<td style="padding: 4pt 8pt 4pt 0;">有効期限 (時間):</td>
-					<td style="padding: 4pt 0;">
-						<input type="text" name="expiresIn" value={form?.expiresInRaw ?? ''} size="6" style="font-family: Verdana, Geneva, sans-serif; font-size: 10pt;" />
-						<span style="margin-left: 8pt;">空欄で無期限</span>
+					<td>有効期限 (時間):</td>
+					<td>
+						<input type="text" name="expiresIn" value={form?.expiresInRaw ?? ''} size="6" />
+						<span> 空欄で無期限</span>
 					</td>
 				</tr>
 				<tr>
-					<td colspan="2" style="padding: 8pt 0;">
-						<button type="submit" style="font-family: Verdana, Geneva, sans-serif; font-size: 10pt;">ban する</button>
+					<td></td>
+					<td>
+						<button type="submit">ban する</button>
 					</td>
 				</tr>
 			</tbody>
@@ -55,27 +56,27 @@
 	{#if data.bans.length === 0}
 		<p>active な ban はありません。</p>
 	{:else}
-		<table style="border-collapse: collapse; border: 1pt solid #cccccc;">
+		<table class="ipban-list">
 			<thead>
-				<tr style="background-color: #f0f0f0;">
-					<th style="padding: 4pt 8pt; text-align: left; border: 1pt solid #cccccc;">IP</th>
-					<th style="padding: 4pt 8pt; text-align: left; border: 1pt solid #cccccc;">理由</th>
-					<th style="padding: 4pt 8pt; text-align: left; border: 1pt solid #cccccc;">ban 日時</th>
-					<th style="padding: 4pt 8pt; text-align: left; border: 1pt solid #cccccc;">解除予定</th>
-					<th style="padding: 4pt 8pt; text-align: left; border: 1pt solid #cccccc;">操作</th>
+				<tr>
+					<th>IP</th>
+					<th>理由</th>
+					<th>ban 日時</th>
+					<th>解除予定</th>
+					<th>操作</th>
 				</tr>
 			</thead>
 			<tbody>
 				{#each data.bans as ban (ban.id)}
 					<tr>
-						<td style="padding: 4pt 8pt; border: 1pt solid #cccccc;">{ban.ip}</td>
-						<td style="padding: 4pt 8pt; border: 1pt solid #cccccc;">{ban.reason || '-'}</td>
-						<td style="padding: 4pt 8pt; border: 1pt solid #cccccc;">{ban.banned_at}</td>
-						<td style="padding: 4pt 8pt; border: 1pt solid #cccccc;">{ban.expires_at ?? '無期限'}</td>
-						<td style="padding: 4pt 8pt; border: 1pt solid #cccccc;">
-							<form method="POST" action="?/unban" style="display: inline;">
+						<td>{ban.ip}</td>
+						<td>{ban.reason || '-'}</td>
+						<td>{ban.banned_at}</td>
+						<td>{ban.expires_at ?? '無期限'}</td>
+						<td>
+							<form method="POST" action="?/unban" class="inline-form">
 								<input type="hidden" name="id" value={ban.id} />
-								<button type="submit" style="font-family: Verdana, Geneva, sans-serif; font-size: 9pt;">unban</button>
+								<button type="submit">unban</button>
 							</form>
 						</td>
 					</tr>
@@ -84,3 +85,30 @@
 		</table>
 	{/if}
 </div>
+
+<style>
+	/* 独自画面の ban 一覧テーブル。DESIGN.md の在パレット色のみで、
+	   行を区切る最小限の装飾（border-bottom）に留める。 */
+	.ipban-list {
+		border-collapse: collapse;
+		font-size: 9pt;
+		margin-top: 4pt;
+	}
+
+	.ipban-list th,
+	.ipban-list td {
+		text-align: left;
+		padding: 2pt 8pt 2pt 0;
+		vertical-align: top;
+	}
+
+	.ipban-list th {
+		color: #828282;
+		font-weight: normal;
+		border-bottom: 1px solid #828282;
+	}
+
+	.ipban-list td {
+		color: #000000;
+	}
+</style>

--- a/src/routes/ipban/+page.svelte
+++ b/src/routes/ipban/+page.svelte
@@ -21,26 +21,26 @@
 	{/if}
 </svelte:head>
 
-<div style="padding: 20pt; font-family: Verdana, Geneva, sans-serif; font-size: 10pt; color: #000000;">
+<div class="hn-form">
 	{#if data.ban}
-		<table style="border-collapse: collapse;">
+		<table>
 			<tbody>
 				<tr>
-					<td style="padding: 4pt 0;">
+					<td>
 						<b>あなたの IP ({data.ip}) は ban されています。</b>
 					</td>
 				</tr>
 				<tr>
-					<td style="padding: 4pt 0;">理由: {data.ban.reason || '(理由未記入)'}</td>
+					<td>理由: {data.ban.reason || '(理由未記入)'}</td>
 				</tr>
 				<tr>
-					<td style="padding: 4pt 0;">ban された日時: {formatBannedAt(data.ban.banned_at)}</td>
+					<td>ban された日時: {formatBannedAt(data.ban.banned_at)}</td>
 				</tr>
 				<tr>
-					<td style="padding: 4pt 0;">解除予定: {formatExpires(data.ban.expires_at)}</td>
+					<td>解除予定: {formatExpires(data.ban.expires_at)}</td>
 				</tr>
 				<tr>
-					<td style="padding: 12pt 0 4pt 0;">
+					<td style="padding-top: 12pt;">
 						共有 IP の場合や心当たりがない場合は、管理者に連絡してください。
 					</td>
 				</tr>
@@ -49,17 +49,19 @@
 
 		{#if data.turnstileSiteKey}
 			<!-- #91: セルフサービス unban。Turnstile を通せば即時 unban する -->
-			<div style="margin-top: 24pt; padding-top: 12pt; border-top: 1px solid #cccccc;">
-				<h3 style="font-size: 11pt; margin: 0 0 8pt 0;">セルフサービス unban</h3>
-				<p style="margin: 4pt 0;">
+			<div class="ipban-section">
+				<p><b>セルフサービス unban</b></p>
+				<p>
 					以下の認証を通すと、即座に ban を解除できます。
 					<br />
 					（24時間以内に 3 回まで試行できます。）
 				</p>
 				{#if form?.unbanError}
-					<p style="color: #b00020; margin: 4pt 0;">{form.unbanError}</p>
+					<p style="color: #ff0000;">{form.unbanError}</p>
 				{/if}
-				<form method="POST" action="?/unban" style="margin-top: 8pt;">
+				<!-- Turnstile widget は Cloudflare 提供の外部 iframe。
+				     親要素は Verdana / pt 規約内に収め、widget 内部の見た目は触らない。 -->
+				<form method="POST" action="?/unban">
 					<div class="cf-turnstile" data-sitekey={data.turnstileSiteKey}></div>
 					<div style="margin-top: 8pt;">
 						<button type="submit">認証して unban する</button>
@@ -68,10 +70,8 @@
 			</div>
 		{:else}
 			<!-- #91: site key 未設定時（dev / REPLACE_ME）はセルフ unban を提供しない -->
-			<div style="margin-top: 24pt; padding-top: 12pt; border-top: 1px solid #cccccc;">
-				<p style="margin: 4pt 0;">
-					現在セルフサービス unban は無効です。管理者にご連絡ください。
-				</p>
+			<div class="ipban-section">
+				<p>現在セルフサービス unban は無効です。管理者にご連絡ください。</p>
 			</div>
 		{/if}
 	{:else}
@@ -79,3 +79,13 @@
 		<p><a href="/">トップへ戻る</a></p>
 	{/if}
 </div>
+
+<style>
+	/* セルフ unban セクションの仕切り。
+	   #828282（DESIGN.md パレット）で 1px 罫線、上に 24pt の余白。 */
+	.ipban-section {
+		margin-top: 24pt;
+		padding-top: 12pt;
+		border-top: 1px solid #828282;
+	}
+</style>

--- a/src/routes/user/[id]/+page.svelte
+++ b/src/routes/user/[id]/+page.svelte
@@ -117,7 +117,7 @@
 		<div style="margin-top: 14pt; padding-left: 50px;">
 			<p style="font-size: 9pt; margin: 0 0 4pt 0;"><b>Change username</b></p>
 			{#if form?.changeUsernameError}
-				<p style="font-size: 9pt; color: #ff6600; margin: 0 0 4pt 0;">{form.changeUsernameError}</p>
+				<p style="font-size: 9pt; color: #ff0000; margin: 0 0 4pt 0;">{form.changeUsernameError}</p>
 			{/if}
 			{#if data.nextUsernameChangeAt}
 				<p style="font-size: 9pt; color: #828282; margin: 0 0 4pt 0;">
@@ -150,7 +150,7 @@
 		<div style="margin-top: 14pt; padding-left: 50px;">
 			<p style="font-size: 9pt; margin: 0 0 4pt 0;"><b>Delete account</b></p>
 			{#if form?.deleteAccountError}
-				<p style="font-size: 9pt; color: #ff6600; margin: 0 0 4pt 0;">{form.deleteAccountError}</p>
+				<p style="font-size: 9pt; color: #ff0000; margin: 0 0 4pt 0;">{form.deleteAccountError}</p>
 			{/if}
 			<p style="font-size: 8pt; color: #828282; margin: 0 0 6pt 0;">
 				アカウントを削除すると元に戻せません。投稿とコメントは <code>[deleted]</code> としてスレッドに残ります。削除済みユーザー名は再取得できません。


### PR DESCRIPTION
## 関連 Issue

closes #107

## 監査・修正内容

### `/admin/ipban`
**違反**:
- 外側 `<div>` に `padding: 20pt`（規約: フォーム container は `.hn-form` の `padding: 10px 0 10px 40px`）
- エラー色 `#cc0000` / 成功色 `#008800`（パレット外）
- 一覧テーブル罫線 `#cccccc` / thead 背景 `#f0f0f0`（パレット外）
- フォーム input/button にインラインで Verdana を上書き（規約: フォーム入力は monospace）

**修正**:
- 外側を `.hn-form` クラスに乗せ替え（共通 CSS から padding / border-spacing / monospace input を継承）
- `#cc0000` → `#ff0000`、`#008800` → `#828282`
- インラインの font-family / font-size 上書きを撤去
- ban 一覧は scoped `<style>` の `.ipban-list` に切り出し、`#828282` の border-bottom のみで整形

### `/ipban`
**違反**:
- 外側 `<div>` に `padding: 20pt`
- エラー色 `#b00020`（パレット外）
- セクション仕切り `border-top: 1px solid #cccccc`（罫線色パレット外）
- `<h3 style="font-size: 11pt">`（type scale は 7-10pt）

**修正**:
- 外側を `.hn-form` に変更
- `#b00020` → `#ff0000`、`#cccccc` → `#828282`
- 11pt 見出しを `<p><b>...</b></p>` に変更
- 仕切りを `.ipban-section`（margin-top: 24pt; padding-top: 12pt; border-top: 1px solid #828282）に切り出し

### `/user/[id]` (Change username / Delete account)
**違反**: エラー文言色 `#ff6600`（オレンジは header / voted state 専用、エラーは `#ff0000`）

**修正**: `changeUsernameError` と `deleteAccountError` の文字色を `#ff0000` に変更

### Turnstile widget 親要素（Issue で「ぶち壊さない範囲かだけ確認」と指定）
規約内を確認:
- 親 `<form>` / `.ipban-section` は Verdana / `.hn-form` 継承で 10pt
- `margin-top: 8pt` のみ、box-shadow / border-radius / gradient / transition なし
- widget 内部（CF iframe）は外部スクリプト由来のため不可侵（ファイル冒頭コメントで明記）

## Test plan

- [x] DESIGN.md の Do / Don't 全項目突き合わせ
- [x] `npx svelte-check`: 新規エラー無し（既存 22 エラーは StoryListItem prop typing 系で本 PR 範囲外）
- [ ] dev で `/admin/ipban` `/ipban` `/user/[id]` を目視確認（v1 リリース前 #105 で実施推奨）

## やらなかったこと（Issue 範囲外）

- `/user/[id]` の `padding-left: 50px` サブセクション indent — 既存の submissions/comments リンク群と一致、本 PR ではスコープ外
- `npx svelte-check` の既存 22 エラー — StoryListItem prop typing で別 Issue 化推奨

## 影響範囲

- 視覚: パレット外色の置換のみ。レイアウト崩れなし
- 機能: 一切変更なし（CSS のみ）