### PR TITLE
fix: svelte-check の 22 件の型エラーを解消 (#112)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@sveltejs/adapter-cloudflare": "^7.0.0",
 				"@sveltejs/kit": "^2.50.2",
 				"@sveltejs/vite-plugin-svelte": "^6.2.4",
+				"@types/node": "^25.6.0",
 				"@vitest/ui": "^4.1.5",
 				"svelte": "^5.49.2",
 				"svelte-check": "^4.3.6",
@@ -1616,6 +1617,7 @@
 			"integrity": "sha512-zG+HmJuSF7eC0e7xt2htlOcEMAdEtlVdb7+gAr+ef08EhtwUsjLxcAwBgUCJY3/5p08OVOxVZti91WfXeuLvsg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
 				"@sveltejs/acorn-typescript": "^1.0.5",
@@ -1659,6 +1661,7 @@
 			"integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
 				"deepmerge": "^4.3.1",
@@ -1723,6 +1726,17 @@
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "25.6.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~7.19.0"
+			}
 		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.7",
@@ -1835,6 +1849,7 @@
 			"integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vitest/utils": "4.1.5",
 				"fflate": "^0.8.2",
@@ -1872,6 +1887,7 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2274,6 +2290,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -2569,6 +2586,7 @@
 			"integrity": "sha512-AqApqNOxVS97V4Ko9UHTHeSuDJrwauJhZpLDs1gYD8Jk48ntCSWD7NxKje+fnGn5Ja1O3u2FzQZHPdifQjXe3w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2683,6 +2701,7 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -2701,12 +2720,20 @@
 				"node": ">=20.18.1"
 			}
 		},
+		"node_modules/undici-types": {
+			"version": "7.19.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/unenv": {
 			"version": "2.0.0-rc.24",
 			"resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
 			"integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"pathe": "^2.0.3"
 			}
@@ -2717,6 +2744,7 @@
 			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -2812,6 +2840,7 @@
 			"integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vitest/expect": "4.1.5",
 				"@vitest/mocker": "4.1.5",
@@ -2920,6 +2949,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"workerd": "bin/workerd"
 			},
@@ -2954,6 +2984,7 @@
 			"integrity": "sha512-R+n3o3tlGzLK9I4fGocPReOuvcnjhtOL2aCVKkHMeuEwt9pPbOO4FxJtx/ec5cIUG/otRyJnfQGCAr9DplBVng==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@cloudflare/kv-asset-handler": "0.4.2",
 				"@cloudflare/unenv-preset": "2.12.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@sveltejs/adapter-cloudflare": "^7.0.0",
 				"@sveltejs/kit": "^2.50.2",
 				"@sveltejs/vite-plugin-svelte": "^6.2.4",
-				"@types/node": "^25.6.0",
+				"@types/node": "^22.0.0",
 				"@vitest/ui": "^4.1.5",
 				"svelte": "^5.49.2",
 				"svelte-check": "^4.3.6",
@@ -1728,14 +1728,14 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.6.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"version": "22.19.17",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+			"integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"undici-types": "~7.19.0"
+				"undici-types": "~6.21.0"
 			}
 		},
 		"node_modules/@types/trusted-types": {
@@ -2721,9 +2721,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.19.2",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"@sveltejs/adapter-cloudflare": "^7.0.0",
 		"@sveltejs/kit": "^2.50.2",
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
-		"@types/node": "^25.6.0",
+		"@types/node": "^22.0.0",
 		"@vitest/ui": "^4.1.5",
 		"svelte": "^5.49.2",
 		"svelte-check": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"@sveltejs/adapter-cloudflare": "^7.0.0",
 		"@sveltejs/kit": "^2.50.2",
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
+		"@types/node": "^25.6.0",
 		"@vitest/ui": "^4.1.5",
 		"svelte": "^5.49.2",
 		"svelte-check": "^4.3.6",

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -31,7 +31,7 @@ function italicize(text: string): string {
  * SQL 側で CASE 置換せず、クライアント表示時に一貫してこのヘルパを通すことで
  * カラム漏れによる本名漏洩を防ぐ。本家HN FAQ #32 相当の挙動。
  */
-export function displayUsername(user: { username: string; deleted?: 0 | 1 | null | undefined }): string {
+export function displayUsername(user: { username: string; deleted?: number | null | undefined }): string {
 	return user.deleted ? '[deleted]' : user.username;
 }
 

--- a/src/routes/item/[id]/+page.svelte
+++ b/src/routes/item/[id]/+page.svelte
@@ -429,7 +429,7 @@
 			</div>
 		{/if}
 
-		{#if form?.error && form?.errorFor === 'comment'}
+		{#if form && 'errorFor' in form && form.errorFor === 'comment' && form.error}
 			<div style="padding-left: 14px; color: #ff0000; font-size: 9pt; margin-bottom: 4px;">{form.error}</div>
 		{/if}
 		{#if data.user && isThreadOpen(data.parentStory.created_at)}
@@ -441,7 +441,7 @@
 					};
 				}}>
 					<input type="hidden" name="parent_id" value={comment.id} />
-					<textarea name="text" rows="6" cols="60">{form?.errorFor === 'comment' ? form?.text ?? '' : ''}</textarea>
+					<textarea name="text" rows="6" cols="60">{form && 'errorFor' in form && form.errorFor === 'comment' && 'text' in form ? form.text ?? '' : ''}</textarea>
 					<br />
 					<button type="submit">reply</button>
 				</form>
@@ -684,7 +684,7 @@
 			</div>
 		{/if}
 
-		{#if form?.error && form?.errorFor === 'comment'}
+		{#if form && 'errorFor' in form && form.errorFor === 'comment' && form.error}
 			<div style="padding-left: 18px; color: #ff0000; font-size: 9pt; margin-bottom: 4px;">{form.error}</div>
 		{/if}
 		{#if data.user && isThreadOpen(data.story.created_at)}
@@ -695,7 +695,7 @@
 						await invalidateAll();
 					};
 				}}>
-					<textarea name="text" rows="6" cols="60">{form?.errorFor === 'comment' ? form?.text ?? '' : ''}</textarea>
+					<textarea name="text" rows="6" cols="60">{form && 'errorFor' in form && form.errorFor === 'comment' && 'text' in form ? form.text ?? '' : ''}</textarea>
 					<br />
 					<button type="submit">add comment</button>
 				</form>

--- a/src/routes/newcomments/+page.svelte
+++ b/src/routes/newcomments/+page.svelte
@@ -35,7 +35,7 @@
 				[commentId]: result.voteState
 			};
 		} else if (res.status === 403) {
-			const result = await res.json();
+			const result: { error?: string } = await res.json();
 			alert(result.error || 'Permission denied');
 		}
 	}

--- a/src/routes/user/[id]/comments/+page.svelte
+++ b/src/routes/user/[id]/comments/+page.svelte
@@ -35,7 +35,7 @@
 				[commentId]: result.voteState
 			};
 		} else if (res.status === 403) {
-			const result = await res.json();
+			const result: { error?: string } = await res.json();
 			alert(result.error || 'Permission denied');
 		}
 	}


### PR DESCRIPTION
## 関連 Issue

closes #112

## 解消したエラー

`npx svelte-check --tsconfig ./tsconfig.json`: **22 ERRORS → 0 ERRORS**

| 系統 | 件数 | 修正内容 |
|---|---|---|
| 1. \`displayUsername\` 引数型不整合 | 13 | \`deleted?: 0 \| 1 \| null \| undefined\` → \`number \| null \| undefined\` に緩和（truthy 判定なので動作変わらず） |
| 2. action result discriminated union | 6 | \`item/[id]/+page.svelte\` で \`'errorFor' in form && form.errorFor === 'comment'\` 型ガード形式に変更（\`as\` キャスト不使用） |
| 3. \`result\` is of type \`unknown\` | 2 | \`await res.json()\` 結果に \`{ error?: string }\` 型注釈追加（fetch レスポンス、ActionResult ではなかった） |
| 4. \`node:crypto\` 解決不能 | 1 | \`@types/node\` を devDependencies に追加（tsconfig 変更不要、moduleResolution: bundler で自動解決） |

## 残る WARNINGS

1 件（\`login/+page.svelte\` の autofocus）。pre-existing で本 Issue 範囲外。

## やらなかったこと

- 動作仕様の変更（型のみ）
- 既存テストの削除・追加

## Test plan

- [x] \`npx svelte-check\` で ERRORS が 0 件
- [x] \`as any\` 不使用、\`--no-verify\` 不使用
- [ ] dev server 起動して /item/[id] の comment 投稿エラー表示が崩れていないこと（v1 リリース前 #105 で）

## 影響範囲

- 動作影響: なし（型注釈変更のみ）
- 視覚影響: なし