### PR TITLE
feat: PC幅メタ行を本家HNと一致 (#114)

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -158,6 +158,19 @@ score = (points - 1) / (hours_since_post + 2) ^ 1.8
 - コメント: 投稿から2時間以内、本人のみ text を編集可能
 - ストーリー編集時は type を再判定（Ask HN: / Show HN: プレフィックス）
 
+### Story-list メタ行 (#114)
+
+13 ページ共通 `StoryListItem.svelte` のメタ行は本家 HN と並びを揃える:
+
+```
+{points} point(s) by {user} {timeAgo} | hide | [past] | {discuss|N comment(s)} | [un-]flag
+```
+
+- `hide` は未ログイン時も表示し、クリックすると `/login` にリダイレクト（本家 HN と同じ挙動）
+- `past` は URL 付きストーリーのみ。`/from?site={domain}` で同ドメインの過去投稿一覧へ
+- コメント数 0 件のときは `discuss`、1 件以上は `{N} comment(s)` に切替
+- `flag` はログイン中で karma 閾値を満たすときだけ表示（`canFlag`）
+
 ### hide 機能
 
 ストーリーをユーザー単位で非表示化する機能（本家HN準拠）。

--- a/src/lib/components/StoryListItem.svelte
+++ b/src/lib/components/StoryListItem.svelte
@@ -140,18 +140,26 @@
 					deleted: story.user_deleted === 1 ? 1 : story.user_deleted === 0 ? 0 : null
 				})}</a>
 			<a href="/item/{story.id}">{timeAgo(story.created_at)}</a> |
-			<a href="/item/{story.id}"
-				>{story.comment_count} comment{story.comment_count !== 1 ? 's' : ''}</a
-			>
 			{#if user}
-				| <a
+				<a
 					href="#hide"
 					onclick={(e) => {
 						e.preventDefault();
 						hide();
 					}}>hide</a
 				>
+			{:else}
+				<a href="/login">hide</a>
 			{/if}
+			{#if story.url}
+				| <a href="/from?site={extractDomain(story.url)}">past</a>
+			{/if}
+			|
+			<a href="/item/{story.id}"
+				>{story.comment_count === 0
+					? 'discuss'
+					: `${story.comment_count} comment${story.comment_count !== 1 ? 's' : ''}`}</a
+			>
 			{#if canFlag}
 				| <a
 					href="#flag"


### PR DESCRIPTION
## 関連 Issue

closes #114

## 修正内容

\`StoryListItem.svelte\` のメタ行を本家 HN の並び・文言・表示条件と一致させる。13 ページ全部の story-list メタ行に反映。

| 項目 | Before | After |
|---|---|---|
| 並び順 | \`time \| comments \| hide \| flag\` | \`time \| hide \| past \| comments \| flag\` |
| 未ログイン時 hide | 非表示 | 表示（クリックで /login へ） |
| past リンク | 無し | URL 付きストーリーに表示（\`/from?site=DOMAIN\`） |
| 0件時の comments 文言 | \`0 comments\` | \`discuss\` |
| 1件以上の comments 文言 | \`N comment(s)\` | \`N comment(s)\`（変更なし） |

## やらなかったこと

- 1件のときの \`1 comment\` 単数形は本家通りそのまま
- スマホ幅対応 → #73
- /item/[id] のメタ行（既に #71 で past 対応済み、本 PR 範囲外）

## Test plan

- [x] \`npx svelte-check\` で **新規エラー無し**（21 既存エラーは PR #113 由来、main にマージ後解消）
- [ ] dev で /newest を未ログイン状態で開き、メタ行が \`time | hide | past | discuss\` の並びになっていること（v1 リリース前 #105 で確認）
- [ ] hide クリックで /login へ遷移すること（未ログイン）

## 視覚比較（参考）

- 当方 (修正前) `<time> | <N comments>`
- 本家 HN `<time> | hide | past | discuss`
- 当方 (修正後) `<time> | hide | past | <N comments or discuss>`

## 影響範囲

13 ページ: \`/\`, \`/newest\`, \`/best\`, \`/active\`, \`/front\`, \`/ask\`, \`/show\`, \`/asknew\`, \`/shownew\`, \`/noobstories\`, \`/from\`, \`/polls\`, \`/search\`