### PR TITLE
feat: /login に next= でログイン後リダイレクト先を指定 (#116)

### DIFF
--- a/src/lib/components/StoryListItem.svelte
+++ b/src/lib/components/StoryListItem.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { page } from '$app/state';
 	import { displayUsername } from '$lib/format';
 	import { timeAgo, extractDomain, isNewUser } from '$lib/ranking';
 	import { canFlagStory, shouldShowPollTag, type UserLike } from '$lib/storyActions';
@@ -57,9 +58,15 @@
 	let canFlag = $derived(canFlagStory(user, story));
 	let showPollTag = $derived(shouldShowPollTag(story, forcePollTag));
 
+	// 未ログインで vote/flag/hide を踏んだ際にログイン後に戻ってくる先（#116）。
+	// /login の safeNext で相対パス検証されるので、そのまま encode して渡せばよい。
+	let loginHref = $derived(
+		`/login?next=${encodeURIComponent(page.url.pathname + page.url.search)}`
+	);
+
 	async function vote() {
 		if (!user) {
-			window.location.href = '/login';
+			window.location.href = loginHref;
 			return;
 		}
 		const res = await fetch('/api/vote', {
@@ -76,7 +83,7 @@
 
 	async function flag() {
 		if (!user) {
-			window.location.href = '/login';
+			window.location.href = loginHref;
 			return;
 		}
 		const res = await fetch('/api/flag', {
@@ -149,7 +156,7 @@
 					}}>hide</a
 				>
 			{:else}
-				<a href="/login">hide</a>
+				<a href={loginHref}>hide</a>
 			{/if}
 			{#if story.url}
 				| <a href="/from?site={extractDomain(story.url)}">past</a>

--- a/src/lib/safe-next.ts
+++ b/src/lib/safe-next.ts
@@ -1,0 +1,26 @@
+/**
+ * `?next=` 等で渡される「ログイン後の戻り先」をオープンリダイレクトから守るバリデータ。
+ * 受理する: '/' で始まり、別オリジンへ抜ける可能性のない相対パスのみ。
+ *
+ * 攻撃カテゴリ:
+ * - `//evil.com` プロトコル相対 → `startsWith('//')` で弾く
+ * - `/\evil.com` バックスラッシュ正規化（Chrome / Firefox は `\` を `/` 扱い）
+ *   → `'\\'` を含む値を弾く
+ * - `\r\n` 改行混入による Header Injection
+ *   → 制御文字（U+0000–U+001F, U+007F）を含む値を弾く
+ * - 絶対 URL (`http://`, `data:` 等) → そもそも '/' で始まらないので弾く
+ *
+ * URL エンコード（`%2F%2Fevil.com` 等）はブラウザがリダイレクト解決時に
+ * デコードしないため、サーバ側で見える文字列のままなら別オリジンには漏れない。
+ */
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS = /[\x00-\x1f\x7f]/;
+
+export function safeNext(raw: string | null | undefined): string {
+	if (!raw) return '/';
+	if (!raw.startsWith('/')) return '/';
+	if (raw.startsWith('//')) return '/';
+	if (raw.includes('\\')) return '/';
+	if (CONTROL_CHARS.test(raw)) return '/';
+	return raw;
+}

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -12,11 +12,24 @@ import {
 import { verifyPassword, hashPassword, createSession } from '$lib/server/auth';
 import { fail, redirect } from '@sveltejs/kit';
 
-export const load: PageServerLoad = async ({ locals }) => {
+/**
+ * `?next=` 経由のオープンリダイレクトを防ぐ。
+ * 受け入れるのは「`/` で始まり `//` で始まらない相対パス」のみ。
+ * 該当しなければ `/` にフォールバックする。
+ */
+function safeNext(raw: string | null | undefined): string {
+	if (!raw) return '/';
+	if (!raw.startsWith('/')) return '/';
+	if (raw.startsWith('//')) return '/';
+	return raw;
+}
+
+export const load: PageServerLoad = async ({ locals, url }) => {
+	const next = safeNext(url.searchParams.get('next'));
 	if (locals.user) {
-		throw redirect(302, '/');
+		throw redirect(302, next);
 	}
-	return {};
+	return { next };
 };
 
 // 自動 ban 閾値（#92）。閾値・継続時間は両方ここで一元管理する。
@@ -106,6 +119,7 @@ export const actions: Actions = {
 		const formData = await request.formData();
 		const username = (formData.get('username') as string)?.trim();
 		const password = formData.get('password') as string;
+		const next = safeNext(formData.get('next') as string | null);
 
 		if (!username || !password) {
 			// バリデーションエラーは攻撃ではないため失敗ログに記録しない（#92）
@@ -143,7 +157,7 @@ export const actions: Actions = {
 			maxAge: 30 * 24 * 60 * 60
 		});
 
-		throw redirect(302, '/');
+		throw redirect(302, next);
 	},
 
 	signup: async ({ request, platform, cookies }) => {
@@ -151,6 +165,7 @@ export const actions: Actions = {
 		const formData = await request.formData();
 		const username = (formData.get('username') as string)?.trim();
 		const password = formData.get('password') as string;
+		const next = safeNext(formData.get('next') as string | null);
 
 		if (!username || !password) {
 			return fail(400, { signupError: 'Username and password are required', signupUsername: username });
@@ -188,6 +203,6 @@ export const actions: Actions = {
 			maxAge: 30 * 24 * 60 * 60
 		});
 
-		throw redirect(302, '/');
+		throw redirect(302, next);
 	}
 };

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -11,20 +11,12 @@ import {
 } from '$lib/server/db';
 import { verifyPassword, hashPassword, createSession } from '$lib/server/auth';
 import { fail, redirect } from '@sveltejs/kit';
-
-/**
- * `?next=` 経由のオープンリダイレクトを防ぐ。
- * 受け入れるのは「`/` で始まり `//` で始まらない相対パス」のみ。
- * 該当しなければ `/` にフォールバックする。
- */
-function safeNext(raw: string | null | undefined): string {
-	if (!raw) return '/';
-	if (!raw.startsWith('/')) return '/';
-	if (raw.startsWith('//')) return '/';
-	return raw;
-}
+import { safeNext } from '$lib/safe-next';
 
 export const load: PageServerLoad = async ({ locals, url }) => {
+	// data.next は safeNext を通った値のみ。バックスラッシュ・プロトコル相対・
+	// 制御文字・絶対 URL は全て '/' に正規化されるので、フォーム再描画で
+	// hidden input に書き戻しても安全。
 	const next = safeNext(url.searchParams.get('next'));
 	if (locals.user) {
 		throw redirect(302, next);

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
 
-	let { form } = $props();
+	let { data, form } = $props();
 </script>
 
 <svelte:head>
@@ -16,6 +16,7 @@
 	<br /><br />
 
 	<form method="POST" action="?/login" use:enhance>
+		<input type="hidden" name="next" value={data.next} />
 		<table>
 			<tbody>
 				<tr>
@@ -41,6 +42,7 @@
 	<br /><br />
 
 	<form method="POST" action="?/signup" use:enhance>
+		<input type="hidden" name="next" value={data.next} />
 		<table>
 			<tbody>
 				<tr>

--- a/tests/unit/safe-next.test.ts
+++ b/tests/unit/safe-next.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { safeNext } from '../../src/lib/safe-next';
+
+describe('safeNext', () => {
+	describe('受理', () => {
+		it('単純な相対パス', () => {
+			expect(safeNext('/')).toBe('/');
+			expect(safeNext('/newest')).toBe('/newest');
+			expect(safeNext('/user/foo')).toBe('/user/foo');
+		});
+
+		it('クエリ・フラグメント付き', () => {
+			expect(safeNext('/newest?p=2')).toBe('/newest?p=2');
+			expect(safeNext('/item/1#23')).toBe('/item/1#23');
+		});
+
+		it('URL エンコードされた相対パス（ブラウザはこれを別オリジンに解決しない）', () => {
+			expect(safeNext('/%2F%2Fevil.com')).toBe('/%2F%2Fevil.com');
+		});
+	});
+
+	describe('拒否（オープンリダイレクト対策）', () => {
+		it('null / undefined / 空文字 → /', () => {
+			expect(safeNext(null)).toBe('/');
+			expect(safeNext(undefined)).toBe('/');
+			expect(safeNext('')).toBe('/');
+		});
+
+		it('プロトコル相対 //evil.com → /', () => {
+			expect(safeNext('//evil.com')).toBe('/');
+			expect(safeNext('//evil.com/path')).toBe('/');
+		});
+
+		it('バックスラッシュ正規化攻撃 /\\evil.com → /', () => {
+			// 主要ブラウザは Location ヘッダ内の '\' を '/' として扱うため、
+			// '/\\evil.com' は実質 '//evil.com' と等価。弾かないと別オリジンへ漏れる。
+			expect(safeNext('/\\evil.com')).toBe('/');
+			expect(safeNext('/\\/evil.com')).toBe('/');
+			expect(safeNext('\\\\evil.com')).toBe('/');
+			expect(safeNext('/path\\with\\backslash')).toBe('/');
+		});
+
+		it('絶対 URL → /', () => {
+			expect(safeNext('http://evil.com')).toBe('/');
+			expect(safeNext('https://evil.com/path')).toBe('/');
+			expect(safeNext('javascript:alert(1)')).toBe('/');
+			expect(safeNext('data:text/html,foo')).toBe('/');
+		});
+
+		it("'/' で始まらない値 → /", () => {
+			expect(safeNext('newest')).toBe('/');
+			expect(safeNext('?p=2')).toBe('/');
+			expect(safeNext(' /newest')).toBe('/');
+		});
+
+		it('制御文字（CRLF Header Injection 対策） → /', () => {
+			expect(safeNext('/path\r\nLocation: https://evil.com')).toBe('/');
+			expect(safeNext('/path\nfoo')).toBe('/');
+			expect(safeNext('/path\tfoo')).toBe('/');
+			expect(safeNext('/path\x00')).toBe('/');
+			expect(safeNext('/path\x7f')).toBe('/');
+		});
+	});
+});


### PR DESCRIPTION
## 関連 Issue

closes #116

## 修正内容

### \`src/routes/login/+page.server.ts\`
- \`load\`: \`url.searchParams.get('next')\` を読み、\`safeNext\` で検証して \`{ next }\` を返す。既ログインなら \`next\` へ即リダイレクト
- \`login\` / \`signup\` action: \`formData.get('next')\` を \`safeNext\` で検証し、成功時に \`next\` へ \`throw redirect(302, ...)\`
- \`safeNext\`: '/' で始まり '//' で始まらない相対パスのみ受理。それ以外は '/' にフォールバック（オープンリダイレクト脆弱性対策）

### \`src/routes/login/+page.svelte\`
- 両フォーム（login / signup）に \`<input type=\"hidden\" name=\"next\" value={data.next} />\` を追加
- \`$props\` から \`data\` も受け取るよう変更

### \`src/lib/components/StoryListItem.svelte\`
- \`import { page } from '$app/state'\` を追加
- \`loginHref\` を \`$derived\` で組み立て: \`/login?next={encodeURIComponent(page.url.pathname + page.url.search)}\`
- 未ログイン時 \`hide\` リンク href を \`loginHref\` に
- \`vote()\` / \`flag()\` の未ログイン時 \`window.location.href\` も \`loginHref\` に

## 動作

未ログインで story-list の \`hide\` / vote / flag を踏むと、\`/login?next=/newest\` 等に遷移。ログイン or signup 後に元のページへ戻る。\`?p=2\` 等のクエリも保持。

## オープンリダイレクト対策

\`safeNext\` は以下のみ受理:
- \`/\` で始まる
- \`//\` では始まらない

外部 URL (\`https://evil.com\`)、プロトコルなし URL (\`evil.com\`)、サーバー相対 URL (\`//evil.com\`) はすべて拒否されて '/' にフォールバック。

## Test plan

- [x] \`npx svelte-check\`: 0 ERRORS
- [x] \`npx vitest run\`: 185 / 185 passed
- [ ] dev で /newest を未ログイン状態で開き、hide → /login?next=%2Fnewest になり、ログイン後に /newest に戻ること
- [ ] /login に手動で \`?next=//evil.com\` を付けてアクセス → ログイン後に '/' に戻る（オープンリダイレクトされない）