### PR TITLE
fix: 本家HNと同じ見た目になるよう CSS を揃える + スマホ幅監査 spec (#73)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 test-results/
 tests/audit/screenshots/
+tests/audit/hn-news-reference.css

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -51,7 +51,7 @@ Links: `#000000` (unvisited), `#828282` (visited). Hover: underline only.
 | ------------- | ----- | ------ | ------------------ |
 | Logo/site name | 10pt | bold   | HN `.pagetop b.hnname` に一致 |
 | Body default  | 10pt  | normal |                    |
-| Item text     | 9pt   | normal | Line-height 14pt   |
+| Item text     | 9pt   | normal | Line-height: ブラウザ既定 (1.2)。本家 HN news.css も未指定 |
 | Form inputs   | 10pt  | normal | Monospace（HN `input` に一致） |
 | Buttons/small | 8pt   | normal |                    |
 | Metadata      | 7pt   | normal | Timestamps, meta   |
@@ -74,9 +74,10 @@ Base font size is `10pt` on html/body. Everything is in `pt`, not `rem` or `px`.
 - Layout: flex, baseline alignment
 - Rank: `min-width: 30px`, right-aligned, `#828282`
 - Upvote: `▲` (Unicode `&#9650;`), `10x10px`, default `#9a9a9a`, hover/voted `#ff6600`
-- Title: `10pt`, line-height `14pt`
+- Title: `10pt`、line-height はブラウザ既定（HN news.css も未指定）。`@media (max-width: 750px)` では `11pt`/`14pt` に拡大（HN mobile @media に一致）
+- Meta line height: ブラウザ既定。`@media (max-width: 750px)` では meta も `9pt` に拡大
 - Domain tag: `8pt`, `#828282`, `margin-left: 5px`
-- Meta line: `7pt`, `#828282`
+- Meta line: `7pt`, `#828282`（mobile では `9pt`、HN mobile に一致）
 
 ### Comments
 
@@ -84,7 +85,7 @@ Base font size is `10pt` on html/body. Everything is in `pt`, not `rem` or `px`.
 - Head: `8pt`, `#828282` (HN `.comhead` に一致)
 - Upvote: `▲` (`&#9650;`), `8pt`, default `#9a9a9a`, hover/voted `#ff6600`
 - Downvote: `▼` (`&#9660;`), `8pt`, default `#9a9a9a`, hover/voted `#ff6600`（karma >= 500 のみ表示）
-- Text: `9pt`, `#000000`, line-height `14pt`
+- Text: `9pt`, `#000000`, line-height はブラウザ既定（HN news.css も未指定）
 - Faded text: `#828282`（points < 1 のコメント）
 - Reply link: `7pt`, `#828282`, underline
 

--- a/src/app.css
+++ b/src/app.css
@@ -103,6 +103,24 @@ a:hover {
 		overflow-wrap: anywhere;
 		word-break: break-word;
 	}
+
+	/* HN mobile: titles and subtext are larger for readability.
+	   Mirror news.css mobile @media rules:
+	     .title    { font-size: 11pt; line-height: 14pt }
+	     .subtext  { font-size: 9pt }
+	*/
+	.story-title-line,
+	.story-title-line a.story-title,
+	.item-detail .item-title,
+	.item-detail .item-title a {
+		font-size: 11pt;
+		line-height: 14pt;
+	}
+
+	.story-meta,
+	.item-detail .item-meta {
+		font-size: 9pt;
+	}
 }
 
 /* Header */

--- a/src/app.css
+++ b/src/app.css
@@ -245,7 +245,6 @@ a:hover {
 
 .story-title-line {
 	font-size: 10pt;
-	line-height: 14pt;
 }
 
 .story-title-line a.story-title {
@@ -271,7 +270,6 @@ a:hover {
 .story-meta {
 	font-size: 7pt;
 	color: #828282;
-	line-height: 12pt;
 }
 
 .story-meta a {
@@ -356,7 +354,6 @@ a:hover {
 	font-size: 9pt;
 	color: #000000;
 	margin-top: 8px;
-	line-height: 14pt;
 }
 
 .item-detail .item-text p {
@@ -450,7 +447,6 @@ a:hover {
 	font-size: 9pt;
 	color: #000000;
 	margin-top: 3px;
-	line-height: 14pt;
 	overflow-wrap: break-word;
 }
 

--- a/tests/audit/audit-mobile-width.spec.ts
+++ b/tests/audit/audit-mobile-width.spec.ts
@@ -1,0 +1,236 @@
+import { test } from '@playwright/test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const OUT_DIR = path.join(__dirname, 'screenshots');
+
+// 当方は本番 (https://hn.llll-ll.com)。AUDIT_OURS_URL で上書き可。
+const OURS_URL = process.env.AUDIT_OURS_URL ?? 'https://hn.llll-ll.com';
+
+const SITES = [
+	{ id: 'ours', baseURL: OURS_URL },
+	{ id: 'hn', baseURL: 'https://news.ycombinator.com' }
+] as const;
+
+// iPhone 相当
+const VIEWPORT = { width: 375, height: 812 };
+
+// 主要ページ。/submit /signup は未認証で /login にリダイレクトされるため /login に集約。
+// /item /user は site ごとに有効な ID が必要なので別 test で扱う。
+const PATHS = [
+	'/',
+	'/newest',
+	'/ask',
+	'/show',
+	'/best',
+	'/active',
+	'/newcomments',
+	'/lists',
+	'/front',
+	'/guidelines',
+	'/faq',
+	'/login'
+] as const;
+
+type OverflowReport = {
+	site: string;
+	path: string;
+	viewport: { width: number; height: number };
+	scrollWidth: number;
+	clientWidth: number;
+	overflow: boolean;
+	offenders: Array<{
+		tag: string;
+		id: string;
+		cls: string;
+		right: number;
+		scrollWidth: number;
+		text: string;
+	}>;
+};
+
+function ensureOut() {
+	if (!fs.existsSync(OUT_DIR)) fs.mkdirSync(OUT_DIR, { recursive: true });
+}
+
+function safePathSeg(p: string): string {
+	if (p === '/') return 'root';
+	return p.replace(/^\//, '').replace(/\//g, '_');
+}
+
+test.beforeAll(() => {
+	ensureOut();
+});
+
+for (const site of SITES) {
+	for (const p of PATHS) {
+		test(`mobile ${site.id} ${p}`, async ({ page }) => {
+			await page.setViewportSize(VIEWPORT);
+			const url = `${site.baseURL}${p}`;
+			const resp = await page.goto(url, { waitUntil: 'load' });
+			// 200/302 以外は検出だけして続行する
+			const status = resp?.status() ?? 0;
+
+			// 水平オーバーフロー判定 + 原因要素
+			const result = await page.evaluate((vw) => {
+				const html = document.documentElement;
+				const body = document.body;
+				const scrollWidth = Math.max(html.scrollWidth, body.scrollWidth);
+				const clientWidth = html.clientWidth;
+				const overflow = scrollWidth > clientWidth + 1;
+
+				const offenders: Array<{
+					tag: string;
+					id: string;
+					cls: string;
+					right: number;
+					scrollWidth: number;
+					text: string;
+				}> = [];
+
+				if (overflow) {
+					const all = document.querySelectorAll<HTMLElement>('*');
+					for (const el of Array.from(all)) {
+						const rect = el.getBoundingClientRect();
+						const right = rect.right;
+						const sw = el.scrollWidth;
+						if (right > vw + 1 || (sw > vw && rect.width >= vw)) {
+							// 親が既に offender ならスキップ（最深部に絞る）
+							let parentOffending = false;
+							let parent = el.parentElement;
+							while (parent) {
+								const pr = parent.getBoundingClientRect();
+								if (pr.right > vw + 1 && pr.width <= rect.width + 1) {
+									// 親も同じくらい広いなら親側に責任がある可能性 → スキップ判定はしない
+									break;
+								}
+								parent = parent.parentElement;
+							}
+							if (parentOffending) continue;
+
+							offenders.push({
+								tag: el.tagName.toLowerCase(),
+								id: el.id || '',
+								cls: typeof el.className === 'string' ? el.className.slice(0, 120) : '',
+								right: Math.round(right),
+								scrollWidth: sw,
+								text: (el.textContent ?? '').replace(/\s+/g, ' ').slice(0, 80)
+							});
+						}
+					}
+				}
+
+				return { scrollWidth, clientWidth, overflow, offenders: offenders.slice(0, 20) };
+			}, VIEWPORT.width);
+
+			const report: OverflowReport = {
+				site: site.id,
+				path: p,
+				viewport: VIEWPORT,
+				scrollWidth: result.scrollWidth,
+				clientWidth: result.clientWidth,
+				overflow: result.overflow,
+				offenders: result.offenders
+			};
+
+			const seg = safePathSeg(p);
+			const stem = `mobile-${site.id}-${seg}`;
+
+			fs.writeFileSync(
+				path.join(OUT_DIR, `${stem}.report.json`),
+				JSON.stringify({ status, ...report }, null, 2)
+			);
+
+			await page.screenshot({
+				path: path.join(OUT_DIR, `${stem}.png`),
+				fullPage: true
+			});
+
+			const html = await page.content();
+			fs.writeFileSync(path.join(OUT_DIR, `${stem}.html`), html);
+
+			// 結果を stdout にも出す（集計しやすさのため）
+			console.log(
+				`[${site.id} ${p}] status=${status} sw=${result.scrollWidth} cw=${result.clientWidth} overflow=${result.overflow} offenders=${result.offenders.length}`
+			);
+		});
+	}
+}
+
+// /item/[id] と /user/[id] は site ごとに別の ID を使う
+const ITEM_USER_TARGETS = [
+	{ site: 'ours', baseURL: OURS_URL, item: 1, user: 'noroshi' },
+	{ site: 'hn', baseURL: 'https://news.ycombinator.com', item: 1, user: 'pg' }
+] as const;
+
+for (const t of ITEM_USER_TARGETS) {
+	for (const sub of [`/item?id=${t.item}`, `/user?id=${t.user}`] as const) {
+		// 当方は /item/[id] と /user/[id] のフォーマット。本家は ?id= フォーマット。
+		// 当方のときだけパスパターンを切り替える
+		const ourPath =
+			t.site === 'ours'
+				? sub.startsWith('/item')
+					? `/item/${t.item}`
+					: `/user/${t.user}`
+				: sub;
+		test(`mobile ${t.site} ${ourPath}`, async ({ page }) => {
+			await page.setViewportSize(VIEWPORT);
+			const url = `${t.baseURL}${ourPath}`;
+			const resp = await page.goto(url, { waitUntil: 'load' });
+			const status = resp?.status() ?? 0;
+
+			const result = await page.evaluate((vw) => {
+				const html = document.documentElement;
+				const body = document.body;
+				const scrollWidth = Math.max(html.scrollWidth, body.scrollWidth);
+				const clientWidth = html.clientWidth;
+				const overflow = scrollWidth > clientWidth + 1;
+				const offenders: Array<{
+					tag: string;
+					id: string;
+					cls: string;
+					right: number;
+					scrollWidth: number;
+					text: string;
+				}> = [];
+				if (overflow) {
+					const all = document.querySelectorAll<HTMLElement>('*');
+					for (const el of Array.from(all)) {
+						const rect = el.getBoundingClientRect();
+						if (rect.right > vw + 1 || (el.scrollWidth > vw && rect.width >= vw)) {
+							offenders.push({
+								tag: el.tagName.toLowerCase(),
+								id: el.id || '',
+								cls:
+									typeof el.className === 'string' ? el.className.slice(0, 120) : '',
+								right: Math.round(rect.right),
+								scrollWidth: el.scrollWidth,
+								text: (el.textContent ?? '').replace(/\s+/g, ' ').slice(0, 80)
+							});
+						}
+					}
+				}
+				return { scrollWidth, clientWidth, overflow, offenders: offenders.slice(0, 20) };
+			}, VIEWPORT.width);
+
+			const seg = safePathSeg(ourPath).replace(/\?/g, '_').replace(/=/g, '_');
+			const stem = `mobile-${t.site}-${seg}`;
+			fs.writeFileSync(
+				path.join(OUT_DIR, `${stem}.report.json`),
+				JSON.stringify({ status, site: t.site, path: ourPath, ...result }, null, 2)
+			);
+			await page.screenshot({
+				path: path.join(OUT_DIR, `${stem}.png`),
+				fullPage: true
+			});
+			const html = await page.content();
+			fs.writeFileSync(path.join(OUT_DIR, `${stem}.html`), html);
+			console.log(
+				`[${t.site} ${ourPath}] status=${status} sw=${result.scrollWidth} cw=${result.clientWidth} overflow=${result.overflow} offenders=${result.offenders.length}`
+			);
+		});
+	}
+}


### PR DESCRIPTION
## 関連 Issue

closes #73

## 経緯と方向修正

当初「水平オーバーフローが無いか」だけを見て「修正不要」と結論したが、Issue の本質は **「本家 HN と同じ見た目か」**（視覚パリティ）。news.ycombinator.com の `news.css` を取得して当方 `src/app.css` と全行突き合わせし、ズレを修正。

## 監査資料

- `tests/audit/audit-mobile-width.spec.ts` (新規) — 375×812 で 14 ページ × 2 サイトのスクショ + HTML + overflow report を生成
- `tests/audit/audit-pc-width.spec.ts` (既存) — 1280×720 の PC 比較
- HN の `news.css` (180 行) を入手して `tests/audit/hn-news-reference.css` に保存（gitignore 済、外部著作物のため）

## CSS 差分マッピング & 修正

| プロパティ | HN news.css | 修正前 | 修正後 |
|---|---|---|---|
| PC `.story-title-line` line-height | 未指定（既定 1.2 = 12pt） | 14pt | **削除（既定に戻す）** |
| PC `.story-meta` line-height | 未指定（既定 1.2 = 8.4pt） | 12pt | **削除（既定に戻す）** |
| PC `.item-detail .item-text` line-height | 未指定 | 14pt | 削除 |
| PC `.comment-text` line-height | 未指定 | 14pt | 削除 |
| Mobile `.title` | `font-size: 11pt; line-height: 14pt` | 10pt のまま | **mobile @media で 11pt/14pt に拡大** |
| Mobile `.subtext` | `font-size: 9pt` | 7pt のまま | **mobile @media で 9pt に拡大** |

行間を browser 既定（font-size × 1.2）に戻すと、本家と同じ「詰まった」レンダリングになる。当方は明示的に 14pt / 12pt を指定していたため間延びしていた。

## 修正後のスクショ評価

| ページ | PC 視覚パリティ | Mobile 視覚パリティ |
|---|---|---|
| /newest | HN とほぼ一致（残差は seed データ件数のみ） | タイトル 11pt + 詰まった行間で HN mobile と並べて視覚一致 |
| /polls | 同上 | 同上 |
| /item/[id] | コメントネスト・本文の行間が HN と一致 | 同上 |

## やらなかったこと（許容差分）

- `.pagetop` color: HN `#222222` / 当方 `#000000`。差は微小、当方ヘッダー class 構造が異なるため変更見送り
- HN mobile の `span.pagetop { display: block; font-size: 12px }`: 当方は flex-wrap で同等の wrapping を実現しており 375px で 1〜2 行に収まる
- seed データ量: 当方 8 件 vs HN 1000+ → 視覚密度は seed 増やすと自然に近づく

## 750px breakpoint 維持

新規 breakpoint 追加なし。HTML 構造変更なし。DESIGN.md パレット外色追加なし。

## Test plan

- [x] svelte-check: 0 ERRORS
- [x] audit-mobile-width.spec.ts (28 tests): all pass、overflow=false 維持
- [x] audit-pc-width.spec.ts (4 tests): all pass
- [x] mobile-ours-newest.png と mobile-hn-newest.png 並べて視覚一致確認
- [ ] 本番デプロイ後に hn.llll-ll.com の各ページが視覚的に HN に一致することを目視確認