### PR TITLE
feat: 全画面網羅で本家HNと視覚パリティ達成 (#73)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -121,6 +121,28 @@ a:hover {
 	.item-detail .item-meta {
 		font-size: 9pt;
 	}
+
+	/* HN mobile: votearrow is scaled 1.3x for touch targets.
+	   Mirrors news.css mobile @media:
+	     .votearrow { transform: scale(1.3); margin-right: 6px; } */
+	.story-vote .upvote,
+	.comment-head .upvote,
+	.comment-head .downvote {
+		transform: scale(1.3);
+		margin-right: 6px;
+	}
+
+	/* /user の about セルは mobile では幅 100% にしてはみ出さないように */
+	.user-profile td {
+		max-width: 100%;
+	}
+
+	.user-profile textarea,
+	.user-profile input[type='text'] {
+		width: 100%;
+		max-width: 100%;
+		box-sizing: border-box;
+	}
 }
 
 /* Header */

--- a/src/app.css
+++ b/src/app.css
@@ -219,9 +219,28 @@ a:hover {
 	color: #000000;
 }
 
-.hn-header-right {
+/* 現在ページの nav リンクを太字に。HN は b タグで囲う形だが
+   ここでは aria-current="page" + .active で同等の見た目にする。 */
+.hn-header-nav a.active,
+.hn-header-nav a[aria-current='page'] {
+	font-weight: bold;
+}
+
+/* HN の右端 topright（asknew/noobstories/日付 等のページ名表示）。
+   常に margin-left: auto で右寄せ。空のときは margin だけ残るが幅0なので問題なし。 */
+.hn-header-pagename {
 	margin-left: auto;
 	white-space: nowrap;
+}
+
+.hn-header-pagename .topright {
+	color: #000000;
+	font-size: 10pt;
+}
+
+.hn-header-right {
+	white-space: nowrap;
+	margin-left: 8px;
 }
 
 .hn-header-right a {

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -881,10 +881,13 @@ export async function getHighlightedComments(
 	const offset = (page - 1) * limit;
 	const conds: string[] = ['c.points >= ?'];
 	const params: (string | number)[] = [minPoints];
-	if (!showdead) conds.push('c.dead = 0');
-	conds.push(
-		'(SELECT COUNT(*) FROM comments cc WHERE cc.story_id = c.story_id AND cc.dead = 0) >= ?'
-	);
+	if (!showdead) {
+		conds.push('c.dead = 0');
+		conds.push('s.dead = 0');
+	}
+	// 相関サブクエリ (SELECT COUNT(*) ...) は N+1 になるため stories.comment_count を使う。
+	// stories.comment_count は dead 含むカウントだが、minStoryCommentCount=3 程度の閾値なら誤差は許容範囲。
+	conds.push('s.comment_count >= ?');
 	params.push(minStoryCommentCount);
 	const whereClause = `WHERE ${conds.join(' AND ')}`;
 

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -855,6 +855,64 @@ export async function getBestComments(
 	return filtered.slice(0, limit);
 }
 
+// /highlights 用: 「目立った会話」を点数 + スレッド盛り上がりで近似する。
+// 条件: コメント点数 >= 5 かつ 所属ストーリーのコメント数 >= 3。
+// /bestcomments （単純な高得点順）と差別化するための専用クエリ。
+export async function getHighlightedComments(
+	db: D1Database,
+	options: {
+		minPoints?: number;
+		minStoryCommentCount?: number;
+		page?: number;
+		limit?: number;
+		currentUserId?: number;
+		showdead?: boolean;
+	} = {}
+): Promise<(CommentRow & { story_title: string })[]> {
+	const {
+		minPoints = 5,
+		minStoryCommentCount = 3,
+		page = 1,
+		limit = 30,
+		currentUserId,
+		showdead = false
+	} = options;
+	const fetchLimit = limit * 3;
+	const offset = (page - 1) * limit;
+	const conds: string[] = ['c.points >= ?'];
+	const params: (string | number)[] = [minPoints];
+	if (!showdead) conds.push('c.dead = 0');
+	conds.push(
+		'(SELECT COUNT(*) FROM comments cc WHERE cc.story_id = c.story_id AND cc.dead = 0) >= ?'
+	);
+	params.push(minStoryCommentCount);
+	const whereClause = `WHERE ${conds.join(' AND ')}`;
+
+	const sql = `
+		SELECT c.*, u.username, u.created_at as user_created_at, u.deleted as user_deleted, u.delay as author_delay, s.title as story_title, ${COMMENT_FLAG_COUNT_SQL}
+		FROM comments c
+		JOIN users u ON c.user_id = u.id
+		JOIN stories s ON c.story_id = s.id
+		${whereClause}
+		ORDER BY c.points DESC, c.created_at DESC
+		LIMIT ? OFFSET ?
+	`;
+	params.push(fetchLimit, offset);
+	const result = await db
+		.prepare(sql)
+		.bind(...params)
+		.all<CommentRow & { story_title: string; author_delay: number }>();
+
+	const now = Date.now();
+	const filtered = result.results.filter((c) => {
+		if (c.user_id === currentUserId) return true;
+		if (c.author_delay <= 0) return true;
+		const visibleAt = new Date(c.created_at).getTime() + c.author_delay * 60 * 1000;
+		return now >= visibleAt;
+	});
+	return filtered.slice(0, limit);
+}
+
 // 新規ユーザー判定は呼び出し側が thresholdMs を指定する。/noobstories では TWO_WEEKS_MS（14日）を渡す。
 // `isNewUser()` のグリーン表示と一貫させるため、しきい値は両者で揃えること。
 export async function getStoriesByNewUsers(

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -21,7 +21,7 @@
 		'/noobstories': 'noobstories',
 		'/noobcomments': 'noobcomments',
 		'/shownew': 'shownew',
-		'/showhn': 'show',
+		'/showhn': 'showhn',
 		'/bestcomments': 'bestcomments',
 		'/best': 'best',
 		'/active': 'active',

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,58 @@
 <script lang="ts">
 	import '../app.css';
+	import { page } from '$app/state';
 
 	let { data, children } = $props();
+
+	type NavItem = { href: string; label: string; topright: string };
+	const navItems: NavItem[] = [
+		{ href: '/newest', label: 'new', topright: 'new' },
+		{ href: '/front', label: 'past', topright: 'past' },
+		{ href: '/newcomments', label: 'comments', topright: 'comments' },
+		{ href: '/ask', label: 'ask', topright: 'ask' },
+		{ href: '/show', label: 'show', topright: 'show' },
+		{ href: '/submit', label: 'submit', topright: 'submit' }
+	];
+
+	// /asknew, /noobstories, /shownew, /noobcomments, /bestcomments, /best, /active,
+	// /highlights, /newpoll, /polls など nav に出ていないがページ名表示は出すパス
+	const extraToprightMap: Record<string, string> = {
+		'/asknew': 'asknew',
+		'/noobstories': 'noobstories',
+		'/noobcomments': 'noobcomments',
+		'/shownew': 'shownew',
+		'/showhn': 'show',
+		'/bestcomments': 'bestcomments',
+		'/best': 'best',
+		'/active': 'active',
+		'/highlights': 'highlights',
+		'/newpoll': 'newpoll',
+		'/polls': 'polls',
+		'/leaders': 'leaders',
+		'/lists': 'lists',
+		'/from': 'from',
+		'/search': 'search',
+		'/login': 'login',
+		'/signup': 'signup',
+		'/logout': 'logout',
+		'/faq': 'faq',
+		'/guidelines': 'guidelines',
+		'/api-docs': 'api',
+		'/admin': 'admin',
+		'/ipban': 'ipban'
+	};
+
+	function isActive(href: string, pathname: string): boolean {
+		// 完全一致のみアクティブ扱い（/ask が /asknew でアクティブにならないように）
+		return pathname === href;
+	}
+
+	function currentTopright(pathname: string): string {
+		const match = navItems.find((n) => n.href === pathname);
+		if (match) return match.topright;
+		if (extraToprightMap[pathname]) return extraToprightMap[pathname];
+		return '';
+	}
 </script>
 
 <svelte:head>
@@ -15,18 +66,22 @@
 			<a href="/" class="hn-header-logo"><img src="/icon-32.webp" alt="ハッカーのろし" width="18" height="18" /></a>
 			<a href="/" class="hn-header-site-name">ハッカーのろし</a>
 			<nav class="hn-header-nav">
-				<a href="/newest">new</a>
-				<span class="nav-separator">|</span>
-				<a href="/front">past</a>
-				<span class="nav-separator">|</span>
-				<a href="/newcomments">comments</a>
-				<span class="nav-separator">|</span>
-				<a href="/ask">ask</a>
-				<span class="nav-separator">|</span>
-				<a href="/show">show</a>
-				<span class="nav-separator">|</span>
-				<a href="/submit">submit</a>
+				{#each navItems as item, i (item.href)}
+					{#if i > 0}
+						<span class="nav-separator">|</span>
+					{/if}
+					<a
+						href={item.href}
+						class:active={isActive(item.href, page.url.pathname)}
+						aria-current={isActive(item.href, page.url.pathname) ? 'page' : undefined}>{item.label}</a
+					>
+				{/each}
 			</nav>
+		</div>
+		<div class="hn-header-pagename">
+			{#if currentTopright(page.url.pathname)}
+				<span class="topright">{currentTopright(page.url.pathname)}</span>
+			{/if}
 		</div>
 		<div class="hn-header-right">
 			{#if data.user}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -32,9 +32,7 @@
 		'/lists': 'lists',
 		'/from': 'from',
 		'/search': 'search',
-		'/login': 'login',
-		'/signup': 'signup',
-		'/logout': 'logout',
+		// /login /signup /logout は header-right の認証リンクとテキストが重複するので topright を出さない
 		'/faq': 'faq',
 		'/guidelines': 'guidelines',
 		'/api-docs': 'api',

--- a/src/routes/best/+page.svelte
+++ b/src/routes/best/+page.svelte
@@ -13,6 +13,10 @@
 	}
 </script>
 
+<div class="best-intro">
+	過去48時間で得点の高い投稿。<code>?h=24</code> のように時間数を変えられます。
+</div>
+
 <div class="story-list">
 	{#each data.stories as story, i (story.id)}
 		{#if !localHiddenIds.has(story.id)}
@@ -33,3 +37,14 @@
 		<a href="/best?p={data.page + 1}">More</a>
 	</div>
 {/if}
+
+<style>
+	.best-intro {
+		padding: 10px 0 0 40px;
+		font-size: 9pt;
+		color: #828282;
+	}
+	.best-intro code {
+		font-family: monospace;
+	}
+</style>

--- a/src/routes/bestcomments/+page.svelte
+++ b/src/routes/bestcomments/+page.svelte
@@ -5,6 +5,7 @@
 	let { data } = $props();
 	let localVoteStates = $state<Record<number, 'up' | 'down' | null> | null>(null);
 	let localPoints = $state<Record<number, number>>({});
+	let collapsed = $state<Record<number, boolean>>({});
 
 	function getVoteState(commentId: number): 'up' | 'down' | null {
 		if (localVoteStates && commentId in localVoteStates) {
@@ -75,7 +76,13 @@
 				| <a href="/item/{comment.parent_id ?? comment.story_id}" style="color: #828282;">parent</a>
 				| <a href="/item/{comment.id}" style="color: #828282;">context</a>
 				| on: <a href="/item/{comment.story_id}">{comment.story_title}</a>
+				{' '}<a
+					href="#toggle"
+					onclick={(e) => { e.preventDefault(); collapsed[comment.id] = !collapsed[comment.id]; }}
+					style="color: #828282;"
+				>{#if collapsed[comment.id]}[+]{:else}[&ndash;]{/if}</a>
 			</div>
+			{#if !collapsed[comment.id]}
 			<div class="comment-text" class:faded={getPoints(comment) < 1} style="padding-left: 14px;">
 				{#each comment.text.split('\n') as paragraph}
 					{#if paragraph.trim()}
@@ -83,6 +90,7 @@
 					{/if}
 				{/each}
 			</div>
+			{/if}
 		</div>
 	{/each}
 </div>

--- a/src/routes/from/+page.server.ts
+++ b/src/routes/from/+page.server.ts
@@ -1,4 +1,3 @@
-import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { getDB, getStoriesByDomain, getVotedStoryIds, getHiddenStoryIds, getFlaggedItemIds } from '$lib/server/db';
 import { extractDomain } from '$lib/ranking';
@@ -8,7 +7,15 @@ export const load: PageServerLoad = async ({ url, platform, locals }) => {
 	const rawSite = url.searchParams.get('site') ?? '';
 	const site = rawSite.trim().toLowerCase().replace(/^www\./, '');
 	if (!site) {
-		throw redirect(303, '/');
+		// HN 同様、引数なしでは空ページを返す
+		return {
+			site: null,
+			stories: [],
+			page: 1,
+			hasMore: false,
+			votedIds: [],
+			flaggedIds: []
+		};
 	}
 	const page = parseInt(url.searchParams.get('p') || '1', 10);
 

--- a/src/routes/from/+page.svelte
+++ b/src/routes/from/+page.svelte
@@ -13,31 +13,35 @@
 	}
 </script>
 
-<div class="from-header">Submissions from {data.site}:</div>
+{#if data.site === null}
+	<div class="from-empty">ドメインを指定してください: <code>?site=example.com</code></div>
+{:else}
+	<div class="from-header">Submissions from {data.site}:</div>
 
-{#if data.stories.length === 0}
-	<div class="from-empty">No submissions from {data.site}</div>
-{/if}
+	{#if data.stories.length === 0}
+		<div class="from-empty">No submissions from {data.site}</div>
+	{/if}
 
-<div class="story-list">
-	{#each data.stories as story, i (story.id)}
-		{#if !localHiddenIds.has(story.id)}
-			<StoryListItem
-				{story}
-				rank={(data.page - 1) * 30 + i + 1}
-				user={data.user}
-				initialVoted={votedIds.has(story.id)}
-				initialFlagged={flaggedIds.has(story.id)}
-				{onhide}
-			/>
-		{/if}
-	{/each}
-</div>
-
-{#if data.hasMore}
-	<div class="more-link">
-		<a href="/from?site={data.site}&p={data.page + 1}">More</a>
+	<div class="story-list">
+		{#each data.stories as story, i (story.id)}
+			{#if !localHiddenIds.has(story.id)}
+				<StoryListItem
+					{story}
+					rank={(data.page - 1) * 30 + i + 1}
+					user={data.user}
+					initialVoted={votedIds.has(story.id)}
+					initialFlagged={flaggedIds.has(story.id)}
+					{onhide}
+				/>
+			{/if}
+		{/each}
 	</div>
+
+	{#if data.hasMore}
+		<div class="more-link">
+			<a href="/from?site={data.site}&p={data.page + 1}">More</a>
+		</div>
+	{/if}
 {/if}
 
 <style>
@@ -51,5 +55,9 @@
 		padding: 10pt 0 10pt 6pt;
 		font-size: 10pt;
 		color: #828282;
+	}
+
+	.from-empty code {
+		font-family: monospace;
 	}
 </style>

--- a/src/routes/front/+page.svelte
+++ b/src/routes/front/+page.svelte
@@ -42,12 +42,13 @@
 </script>
 
 <div class="front-nav">
-	{formatDay(data.day)} (UTC) より前に戻る:
-	<a href="/front?day={shiftDay(data.day, -1)}">1日</a>,
-	<a href="/front?day={shiftMonth(data.day, -1)}">1ヶ月</a>,
-	<a href="/front?day={shiftYear(data.day, -1)}">1年</a>。
-	先に進む:
-	<a href="/front?day={shiftDay(data.day, 1)}">1日</a>。
+	<div class="front-nav-line">{formatDay(data.day)} (UTC) のストーリー。</div>
+	<div class="front-nav-line">
+		<a href="/front?day={shiftDay(data.day, -1)}">1日前</a> /
+		<a href="/front?day={shiftMonth(data.day, -1)}">1ヶ月前</a> /
+		<a href="/front?day={shiftYear(data.day, -1)}">1年前</a> へ。
+		<a href="/front?day={shiftDay(data.day, 1)}">1日後</a> へ。
+	</div>
 </div>
 
 {#if data.stories.length === 0}
@@ -80,6 +81,10 @@
 		padding: 6pt 0 6pt 6pt;
 		font-size: 9pt;
 		color: #000000;
+	}
+
+	.front-nav-line {
+		padding: 1pt 0;
 	}
 
 	.front-nav a {

--- a/src/routes/highlights/+page.server.ts
+++ b/src/routes/highlights/+page.server.ts
@@ -1,13 +1,15 @@
 import type { PageServerLoad } from './$types';
-import { getDB, getBestComments, getCommentVoteStates, getFlaggedItemIds } from '$lib/server/db';
+import { getDB, getHighlightedComments, getCommentVoteStates, getFlaggedItemIds } from '$lib/server/db';
 
 export const load: PageServerLoad = async ({ url, platform, locals }) => {
 	const db = getDB(platform);
 	const page = parseInt(url.searchParams.get('p') || '1', 10);
 	const showdead = locals.user?.showdead === 1;
+	// /bestcomments と差別化: 点数 5pt 以上 + ストーリー内コメント数 3 以上のスレッドのみ。
 	// 60件取得して delay フィルタ後にも 30件埋まる確率を上げ、hasMore を確実に判定する
-	let comments = await getBestComments(db, {
-		// sinceMs を指定しない => 全期間
+	let comments = await getHighlightedComments(db, {
+		minPoints: 5,
+		minStoryCommentCount: 3,
 		page,
 		limit: 60,
 		currentUserId: locals.user?.id,

--- a/src/routes/highlights/+page.svelte
+++ b/src/routes/highlights/+page.svelte
@@ -5,6 +5,7 @@
 	let { data } = $props();
 	let localVoteStates = $state<Record<number, 'up' | 'down' | null> | null>(null);
 	let localPoints = $state<Record<number, number>>({});
+	let collapsed = $state<Record<number, boolean>>({});
 
 	function getVoteState(commentId: number): 'up' | 'down' | null {
 		if (localVoteStates && commentId in localVoteStates) {
@@ -75,7 +76,13 @@
 				| <a href="/item/{comment.parent_id ?? comment.story_id}" style="color: #828282;">parent</a>
 				| <a href="/item/{comment.id}" style="color: #828282;">context</a>
 				| on: <a href="/item/{comment.story_id}">{comment.story_title}</a>
+				{' '}<a
+					href="#toggle"
+					onclick={(e) => { e.preventDefault(); collapsed[comment.id] = !collapsed[comment.id]; }}
+					style="color: #828282;"
+				>{#if collapsed[comment.id]}[+]{:else}[&ndash;]{/if}</a>
 			</div>
+			{#if !collapsed[comment.id]}
 			<div class="comment-text" class:faded={getPoints(comment) < 1} style="padding-left: 14px;">
 				{#each comment.text.split('\n') as paragraph}
 					{#if paragraph.trim()}
@@ -83,6 +90,7 @@
 					{/if}
 				{/each}
 			</div>
+			{/if}
 		</div>
 	{/each}
 </div>

--- a/src/routes/item/[id]/+page.svelte
+++ b/src/routes/item/[id]/+page.svelte
@@ -282,13 +282,17 @@
 		collapsed[commentId] = !collapsed[commentId];
 	}
 
+	// id → CommentNode の Map を 1 回だけ構築して isHidden 内の祖先 lookup を O(1) にする。
+	// 以前は commentTree.find() を毎回走らせており O(N×depth×N) で大規模スレッドで重かった。
+	let commentById = $derived(new Map(commentTree.map((c) => [c.id, c])));
+
 	function isHidden(comment: CommentNode): boolean {
 		// 自身は表示するが、祖先のいずれかが閉じていれば非表示。
-		// commentTree は flatten 済みなので、parent_id を辿ってチェックする。
+		// parent_id を辿って collapsed 状態を確認する。
 		let pid = comment.parent_id;
 		while (pid) {
 			if (collapsed[pid]) return true;
-			const parent = commentTree.find((c) => c.id === pid);
+			const parent = commentById.get(pid);
 			if (!parent) break;
 			pid = parent.parent_id;
 		}

--- a/src/routes/item/[id]/+page.svelte
+++ b/src/routes/item/[id]/+page.svelte
@@ -240,7 +240,60 @@
 		return result;
 	}
 
-	let commentTree = $derived(flattenTree(buildCommentTree(data.comments)));
+	// 子孫の総数。`[+] N replies` 表示と「閉じてるとき子孫を非表示」の判定に使う。
+	function countDescendants(node: CommentNode): number {
+		let n = 0;
+		for (const c of node.children) {
+			n += 1 + countDescendants(c);
+		}
+		return n;
+	}
+
+	let commentRoots = $derived(buildCommentTree(data.comments));
+	let commentTree = $derived(flattenTree(commentRoots));
+	let descendantCounts = $derived(
+		Object.fromEntries(commentTree.map((c) => [c.id, countDescendants(c)])) as Record<number, number>
+	);
+
+	// DFS 順での「次のコメント」「現在ノードがぶら下がるルートID」を id ごとに引けるよう
+	// マップにしておく。HN 互換の `root | parent | next` リンク用。
+	let nextCommentId = $derived.by(() => {
+		const map: Record<number, number> = {};
+		for (let i = 0; i < commentTree.length - 1; i++) {
+			map[commentTree[i].id] = commentTree[i + 1].id;
+		}
+		return map;
+	});
+	let rootCommentId = $derived.by(() => {
+		const map: Record<number, number> = {};
+		function walk(node: CommentNode, rootId: number) {
+			map[node.id] = rootId;
+			for (const c of node.children) walk(c, rootId);
+		}
+		for (const r of commentRoots) walk(r, r.id);
+		return map;
+	});
+
+	// 各コメントの折りたたみ状態（true = 閉じている）。HN は全コメントで使えるので
+	// id をキーに $state で保持する。フロントエンド完結。
+	let collapsed = $state<Record<number, boolean>>({});
+
+	function toggleCollapsed(commentId: number) {
+		collapsed[commentId] = !collapsed[commentId];
+	}
+
+	function isHidden(comment: CommentNode): boolean {
+		// 自身は表示するが、祖先のいずれかが閉じていれば非表示。
+		// commentTree は flatten 済みなので、parent_id を辿ってチェックする。
+		let pid = comment.parent_id;
+		while (pid) {
+			if (collapsed[pid]) return true;
+			const parent = commentTree.find((c) => c.id === pid);
+			if (!parent) break;
+			pid = parent.parent_id;
+		}
+		return false;
+	}
 
 	async function voteStory() {
 		if (!data.user) {
@@ -450,7 +503,8 @@
 
 		<div class="comments-section" style="padding-left: 0;">
 			{#each commentTree as child}
-				<div class="comment-item" style="padding-left: {child.depth * 40}px;">
+				{#if !isHidden(child)}
+				<div class="comment-item" id="item-{child.id}" style="padding-left: {child.depth * 40}px;">
 					<div class="comment-head">
 						<span class="comment-vote">
 							<button
@@ -474,7 +528,28 @@
 						</span>
 						<a href="/user/{child.username}" style={isNewUser(child.user_created_at) ? 'color: #3c963c;' : ''}>{displayUsername({ username: child.username, deleted: child.user_deleted })}</a>
 						<a href="/item/{child.id}">{timeAgo(child.created_at)}</a>
+						{#if child.parent_id && child.parent_id !== comment.id}
+							| <a href="#item-{rootCommentId[child.id]}" style="color: #828282;">root</a>
+							| <a href="#item-{child.parent_id}" style="color: #828282;">parent</a>
+						{/if}
+						{#if nextCommentId[child.id]}
+							| <a href="#item-{nextCommentId[child.id]}" style="color: #828282;">next</a>
+						{/if}
+						<span class="comment-toggle">
+							{' '}<a
+								href="#toggle"
+								onclick={(e) => {
+									e.preventDefault();
+									toggleCollapsed(child.id);
+								}}
+								style="color: #828282;"
+							>{#if collapsed[child.id]}[+]{:else}[&ndash;]{/if}</a>
+							{#if collapsed[child.id] && descendantCounts[child.id] > 0}
+								<span style="color: #828282;"> ({descendantCounts[child.id]} {descendantCounts[child.id] === 1 ? 'reply' : 'replies'})</span>
+							{/if}
+						</span>
 					</div>
+					{#if !collapsed[child.id]}
 					{#if editingCommentId === child.id}
 						<div class="comment-form" style="padding-left: 0;">
 							<form method="POST" action="?/editComment" use:enhance={() => {
@@ -547,7 +622,9 @@
 							</div>
 						{/if}
 					{/if}
+					{/if}
 				</div>
+				{/if}
 			{/each}
 		</div>
 	</div>
@@ -704,7 +781,8 @@
 
 		<div class="comments-section" id="comments" style="padding-left: 0;">
 			{#each commentTree as comment}
-				<div class="comment-item" style="padding-left: {comment.depth * 40}px;">
+				{#if !isHidden(comment)}
+				<div class="comment-item" id="item-{comment.id}" style="padding-left: {comment.depth * 40}px;">
 					<div class="comment-head">
 						<span class="comment-vote">
 							<button
@@ -728,7 +806,28 @@
 						</span>
 						<a href="/user/{comment.username}" style={isNewUser(comment.user_created_at) ? 'color: #3c963c;' : ''}>{displayUsername({ username: comment.username, deleted: comment.user_deleted })}</a>
 						<a href="/item/{comment.id}">{timeAgo(comment.created_at)}</a>
+						{#if comment.parent_id}
+							| <a href="#item-{rootCommentId[comment.id]}" style="color: #828282;">root</a>
+							| <a href="#item-{comment.parent_id}" style="color: #828282;">parent</a>
+						{/if}
+						{#if nextCommentId[comment.id]}
+							| <a href="#item-{nextCommentId[comment.id]}" style="color: #828282;">next</a>
+						{/if}
+						<span class="comment-toggle">
+							{' '}<a
+								href="#toggle"
+								onclick={(e) => {
+									e.preventDefault();
+									toggleCollapsed(comment.id);
+								}}
+								style="color: #828282;"
+							>{#if collapsed[comment.id]}[+]{:else}[&ndash;]{/if}</a>
+							{#if collapsed[comment.id] && descendantCounts[comment.id] > 0}
+								<span style="color: #828282;"> ({descendantCounts[comment.id]} {descendantCounts[comment.id] === 1 ? 'reply' : 'replies'})</span>
+							{/if}
+						</span>
 					</div>
+					{#if !collapsed[comment.id]}
 					{#if editingCommentId === comment.id}
 						<div class="comment-form" style="padding-left: 0;">
 							<form method="POST" action="?/editComment" use:enhance={() => {
@@ -801,7 +900,9 @@
 							</div>
 						{/if}
 					{/if}
+					{/if}
 				</div>
+				{/if}
 			{/each}
 		</div>
 	</div>

--- a/src/routes/item/[id]/+page.svelte
+++ b/src/routes/item/[id]/+page.svelte
@@ -398,7 +398,7 @@
 			{/if}
 		</div>
 		{#if editingCommentId === comment.id}
-			<div class="comment-form" style="padding-left: 14px;">
+			<div class="comment-form" style="padding-left: 0;">
 				<form method="POST" action="?/editComment" use:enhance={() => {
 					return async ({ update }) => {
 						editingCommentId = null;
@@ -420,7 +420,7 @@
 				</form>
 			</div>
 		{:else}
-			<div class="comment-text" class:faded={targetCommentPoints < 1} style="padding-left: 14px;">
+			<div class="comment-text" class:faded={targetCommentPoints < 1} style="padding-left: 0;">
 				{#each comment.text.split('\n') as paragraph}
 					{#if paragraph.trim()}
 						<p>{@html formatText(paragraph)}</p>
@@ -430,10 +430,10 @@
 		{/if}
 
 		{#if form && 'errorFor' in form && form.errorFor === 'comment' && form.error}
-			<div style="padding-left: 14px; color: #ff0000; font-size: 9pt; margin-bottom: 4px;">{form.error}</div>
+			<div style="padding-left: 0; color: #ff0000; font-size: 9pt; margin-bottom: 4px;">{form.error}</div>
 		{/if}
 		{#if data.user && isThreadOpen(data.parentStory.created_at)}
-			<div class="comment-form" style="padding-left: 14px;">
+			<div class="comment-form" style="padding-left: 0;">
 				<form method="POST" action="?/comment" use:enhance={() => {
 					return async ({ update }) => {
 						await update();
@@ -476,7 +476,7 @@
 						<a href="/item/{child.id}">{timeAgo(child.created_at)}</a>
 					</div>
 					{#if editingCommentId === child.id}
-						<div class="comment-form" style="padding-left: 14px;">
+						<div class="comment-form" style="padding-left: 0;">
 							<form method="POST" action="?/editComment" use:enhance={() => {
 								return async ({ update }) => {
 									editingCommentId = null;
@@ -498,7 +498,7 @@
 							</form>
 						</div>
 					{:else}
-						<div class="comment-text" class:faded={getCommentPoints(child) < 1} style="padding-left: 14px;">
+						<div class="comment-text" class:faded={getCommentPoints(child) < 1} style="padding-left: 0;">
 							{#each child.text.split('\n') as paragraph}
 								{#if paragraph.trim()}
 									<p>{@html formatText(paragraph)}</p>
@@ -507,7 +507,7 @@
 						</div>
 					{/if}
 					{#if data.user}
-						<div class="comment-reply" style="padding-left: 14px;">
+						<div class="comment-reply" style="padding-left: 0;">
 							{#if isThreadOpen(data.parentStory.created_at)}
 								<a
 									href="#reply"
@@ -531,7 +531,7 @@
 							{/if}
 						</div>
 						{#if isThreadOpen(data.parentStory.created_at) && replyTo === child.id}
-							<div class="comment-form" style="padding-left: 14px;">
+							<div class="comment-form" style="padding-left: 0;">
 								<form method="POST" action="?/comment" use:enhance={() => {
 									return async ({ update }) => {
 										replyTo = null;
@@ -730,7 +730,7 @@
 						<a href="/item/{comment.id}">{timeAgo(comment.created_at)}</a>
 					</div>
 					{#if editingCommentId === comment.id}
-						<div class="comment-form" style="padding-left: 14px;">
+						<div class="comment-form" style="padding-left: 0;">
 							<form method="POST" action="?/editComment" use:enhance={() => {
 								return async ({ update }) => {
 									editingCommentId = null;
@@ -752,7 +752,7 @@
 							</form>
 						</div>
 					{:else}
-						<div class="comment-text" class:faded={getCommentPoints(comment) < 1} style="padding-left: 14px;">
+						<div class="comment-text" class:faded={getCommentPoints(comment) < 1} style="padding-left: 0;">
 							{#each comment.text.split('\n') as paragraph}
 								{#if paragraph.trim()}
 									<p>{@html formatText(paragraph)}</p>
@@ -761,7 +761,7 @@
 						</div>
 					{/if}
 					{#if data.user}
-						<div class="comment-reply" style="padding-left: 14px;">
+						<div class="comment-reply" style="padding-left: 0;">
 							{#if isThreadOpen(data.story.created_at)}
 								<a
 									href="#reply"
@@ -785,7 +785,7 @@
 							{/if}
 						</div>
 						{#if isThreadOpen(data.story.created_at) && replyTo === comment.id}
-							<div class="comment-form" style="padding-left: 14px;">
+							<div class="comment-form" style="padding-left: 0;">
 								<form method="POST" action="?/comment" use:enhance={() => {
 									return async ({ update }) => {
 										replyTo = null;

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -17,14 +17,14 @@
 
 	<form method="POST" action="?/login" use:enhance>
 		<input type="hidden" name="next" value={data.next} />
-		<div class="login-row">
+		<label class="login-row">
 			username:
 			<input type="text" name="username" value={form?.loginUsername ?? ''} autocomplete="username" autocorrect="off" spellcheck="false" autocapitalize="off" autofocus />
-		</div>
-		<div class="login-row">
+		</label>
+		<label class="login-row">
 			password:
 			<input type="password" name="password" autocomplete="current-password" />
-		</div>
+		</label>
 		<button type="submit">login</button>
 	</form>
 
@@ -38,14 +38,14 @@
 
 	<form method="POST" action="?/signup" use:enhance>
 		<input type="hidden" name="next" value={data.next} />
-		<div class="login-row">
+		<label class="login-row">
 			username:
 			<input type="text" name="username" value={form?.signupUsername ?? ''} autocomplete="username" autocorrect="off" spellcheck="false" autocapitalize="off" />
-		</div>
-		<div class="login-row">
+		</label>
+		<label class="login-row">
 			password:
 			<input type="password" name="password" autocomplete="new-password" />
-		</div>
+		</label>
 		<button type="submit">create account</button>
 	</form>
 
@@ -57,6 +57,7 @@
 
 <style>
 	.login-row {
+		display: block;
 		margin-bottom: 8pt;
 	}
 	.login-row input {

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -17,19 +17,14 @@
 
 	<form method="POST" action="?/login" use:enhance>
 		<input type="hidden" name="next" value={data.next} />
-		<table>
-			<tbody>
-				<tr>
-					<td>username:</td>
-					<td><input type="text" name="username" value={form?.loginUsername ?? ''} autocomplete="username" autocorrect="off" spellcheck="false" autocapitalize="off" autofocus /></td>
-				</tr>
-				<tr>
-					<td>password:</td>
-					<td><input type="password" name="password" autocomplete="current-password" /></td>
-				</tr>
-			</tbody>
-		</table>
-		<br />
+		<div class="login-row">
+			username:
+			<input type="text" name="username" value={form?.loginUsername ?? ''} autocomplete="username" autocorrect="off" spellcheck="false" autocapitalize="off" autofocus />
+		</div>
+		<div class="login-row">
+			password:
+			<input type="password" name="password" autocomplete="current-password" />
+		</div>
 		<button type="submit">login</button>
 	</form>
 
@@ -43,19 +38,14 @@
 
 	<form method="POST" action="?/signup" use:enhance>
 		<input type="hidden" name="next" value={data.next} />
-		<table>
-			<tbody>
-				<tr>
-					<td>username:</td>
-					<td><input type="text" name="username" value={form?.signupUsername ?? ''} autocomplete="username" autocorrect="off" spellcheck="false" autocapitalize="off" /></td>
-				</tr>
-				<tr>
-					<td>password:</td>
-					<td><input type="password" name="password" autocomplete="new-password" /></td>
-				</tr>
-			</tbody>
-		</table>
-		<br />
+		<div class="login-row">
+			username:
+			<input type="text" name="username" value={form?.signupUsername ?? ''} autocomplete="username" autocorrect="off" spellcheck="false" autocapitalize="off" />
+		</div>
+		<div class="login-row">
+			password:
+			<input type="password" name="password" autocomplete="new-password" />
+		</div>
 		<button type="submit">create account</button>
 	</form>
 
@@ -64,3 +54,19 @@
 		Passwords should be at least 8 characters.
 	</div>
 </div>
+
+<style>
+	.login-row {
+		margin-bottom: 8pt;
+	}
+	.login-row input {
+		width: 220px;
+		margin-left: 4px;
+	}
+	@media (max-width: 750px) {
+		.login-row input {
+			width: 100%;
+			max-width: 220px;
+		}
+	}
+</style>

--- a/src/routes/newcomments/+page.svelte
+++ b/src/routes/newcomments/+page.svelte
@@ -5,6 +5,8 @@
 	let { data } = $props();
 	let localVoteStates = $state<Record<number, 'up' | 'down' | null> | null>(null);
 	let localPoints = $state<Record<number, number>>({});
+	// HN 互換: 各コメントを `[–]`/`[+]` で折りたたむフロント完結トグル
+	let collapsed = $state<Record<number, boolean>>({});
 
 	function getVoteState(commentId: number): 'up' | 'down' | null {
 		if (localVoteStates && commentId in localVoteStates) {
@@ -74,7 +76,13 @@
 				| <a href="/item/{comment.parent_id ?? comment.story_id}" style="color: #828282;">parent</a>
 				| <a href="/item/{comment.id}" style="color: #828282;">context</a>
 				| on: <a href="/item/{comment.story_id}">{comment.story_title}</a>
+				{' '}<a
+					href="#toggle"
+					onclick={(e) => { e.preventDefault(); collapsed[comment.id] = !collapsed[comment.id]; }}
+					style="color: #828282;"
+				>{#if collapsed[comment.id]}[+]{:else}[&ndash;]{/if}</a>
 			</div>
+			{#if !collapsed[comment.id]}
 			<div class="comment-text" class:faded={getPoints(comment) < 1} style="padding-left: 14px;">
 				{#each comment.text.split('\n') as paragraph}
 					{#if paragraph.trim()}
@@ -82,6 +90,7 @@
 					{/if}
 				{/each}
 			</div>
+			{/if}
 		</div>
 	{/each}
 </div>

--- a/src/routes/noobcomments/+page.svelte
+++ b/src/routes/noobcomments/+page.svelte
@@ -5,6 +5,7 @@
 	let { data } = $props();
 	let localVoteStates = $state<Record<number, 'up' | 'down' | null> | null>(null);
 	let localPoints = $state<Record<number, number>>({});
+	let collapsed = $state<Record<number, boolean>>({});
 
 	function getVoteState(commentId: number): 'up' | 'down' | null {
 		if (localVoteStates && commentId in localVoteStates) {
@@ -74,7 +75,13 @@
 				| <a href="/item/{comment.parent_id ?? comment.story_id}" style="color: #828282;">parent</a>
 				| <a href="/item/{comment.id}" style="color: #828282;">context</a>
 				| on: <a href="/item/{comment.story_id}">{comment.story_title}</a>
+				{' '}<a
+					href="#toggle"
+					onclick={(e) => { e.preventDefault(); collapsed[comment.id] = !collapsed[comment.id]; }}
+					style="color: #828282;"
+				>{#if collapsed[comment.id]}[+]{:else}[&ndash;]{/if}</a>
 			</div>
+			{#if !collapsed[comment.id]}
 			<div class="comment-text" class:faded={getPoints(comment) < 1} style="padding-left: 14px;">
 				{#each comment.text.split('\n') as paragraph}
 					{#if paragraph.trim()}
@@ -82,6 +89,7 @@
 					{/if}
 				{/each}
 			</div>
+			{/if}
 		</div>
 	{/each}
 </div>

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -9,6 +9,7 @@
 	let localHiddenIds = $state<Set<number>>(new Set());
 	let localVoteStates = $state<Record<number, 'up' | 'down' | null> | null>(null);
 	let localCommentPoints = $state<Record<number, number>>({});
+	let collapsed = $state<Record<number, boolean>>({});
 
 	function isHidden(id: number): boolean {
 		return localHiddenIds.has(id);
@@ -130,7 +131,13 @@
 						| <a href="/item/{comment.parent_id ?? comment.story_id}" style="color: #828282;">parent</a>
 						| <a href="/item/{comment.id}" style="color: #828282;">context</a>
 						| on: <a href="/item/{comment.story_id}">{comment.story_title}</a>
+						{' '}<a
+							href="#toggle"
+							onclick={(e) => { e.preventDefault(); collapsed[comment.id] = !collapsed[comment.id]; }}
+							style="color: #828282;"
+						>{#if collapsed[comment.id]}[+]{:else}[&ndash;]{/if}</a>
 					</div>
+					{#if !collapsed[comment.id]}
 					<div class="comment-text" class:faded={getCommentPoints(comment) < 1} style="padding-left: 14px;">
 						{#each comment.text.split('\n') as paragraph}
 							{#if paragraph.trim()}
@@ -138,6 +145,7 @@
 							{/if}
 						{/each}
 					</div>
+					{/if}
 				</div>
 			{/each}
 		</div>

--- a/src/routes/show/+page.svelte
+++ b/src/routes/show/+page.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <div class="show-intro" style="padding: 10px 0 0 40px; font-size: 9pt; color: #828282;">
-	投稿前に <a href="/showhn">Show HN ルール</a> をお読みください。<a href="/show?p=newest">最新の Show HN</a> も眺めてみるとよいでしょう。<a href="/launches">最新の Launch HN</a> もあります。
+	投稿前に <a href="/showhn">Show HN ルール</a> をお読みください。<a href="/shownew">最新の Show HN</a> も眺めてみるとよいでしょう。
 </div>
 
 <div class="story-list">

--- a/src/routes/show/+page.svelte
+++ b/src/routes/show/+page.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <div class="show-intro" style="padding: 10px 0 0 40px; font-size: 9pt; color: #828282;">
-	投稿前に <a href="/showhn">Show HN ルール</a> をお読みください。<a href="/show?p=newest">最新の Show HN</a> も眺めてみるとよいでしょう。
+	投稿前に <a href="/showhn">Show HN ルール</a> をお読みください。<a href="/show?p=newest">最新の Show HN</a> も眺めてみるとよいでしょう。<a href="/launches">最新の Launch HN</a> もあります。
 </div>
 
 <div class="story-list">

--- a/src/routes/user/[id]/+page.svelte
+++ b/src/routes/user/[id]/+page.svelte
@@ -8,6 +8,16 @@
 		return date.toISOString().split('T')[0];
 	}
 
+	function formatCreated(dateString: string): string {
+		const date = new Date(dateString);
+		return date.toLocaleDateString('en-US', {
+			year: 'numeric',
+			month: 'long',
+			day: 'numeric',
+			timeZone: 'UTC'
+		});
+	}
+
 	function formatNextChange(dateString: string | null | undefined): string {
 		if (!dateString) return '';
 		return new Date(dateString).toISOString().split('T')[0];
@@ -31,7 +41,7 @@
 					</tr>
 					<tr>
 						<td style="vertical-align: top; text-align: right; padding-right: 4px;">created:</td>
-						<td><a href="/front?day={formatDate(data.profile.created_at)}">{formatDate(data.profile.created_at)}</a></td>
+						<td><a href="/front?day={formatDate(data.profile.created_at)}">{formatCreated(data.profile.created_at)}</a></td>
 					</tr>
 					<tr>
 						<td style="vertical-align: top; text-align: right; padding-right: 4px;">karma:</td>
@@ -97,7 +107,7 @@
 				</tr>
 				<tr>
 					<td style="vertical-align: top; text-align: right; padding-right: 4px;">created:</td>
-					<td><a href="/front?day={formatDate(data.profile.created_at)}">{formatDate(data.profile.created_at)}</a></td>
+					<td><a href="/front?day={formatDate(data.profile.created_at)}">{formatCreated(data.profile.created_at)}</a></td>
 				</tr>
 				<tr>
 					<td style="vertical-align: top; text-align: right; padding-right: 4px;">karma:</td>

--- a/src/routes/user/[id]/comments/+page.svelte
+++ b/src/routes/user/[id]/comments/+page.svelte
@@ -5,6 +5,7 @@
 	let { data } = $props();
 	let localVoteStates = $state<Record<number, 'up' | 'down' | null> | null>(null);
 	let localPoints = $state<Record<number, number>>({});
+	let collapsed = $state<Record<number, boolean>>({});
 
 	function getVoteState(commentId: number): 'up' | 'down' | null {
 		if (localVoteStates && commentId in localVoteStates) {
@@ -74,7 +75,13 @@
 				| <a href="/item/{comment.parent_id ?? comment.story_id}" style="color: #828282;">parent</a>
 				| <a href="/item/{comment.id}" style="color: #828282;">context</a>
 				| on: <a href="/item/{comment.story_id}">{comment.story_title}</a>
+				{' '}<a
+					href="#toggle"
+					onclick={(e) => { e.preventDefault(); collapsed[comment.id] = !collapsed[comment.id]; }}
+					style="color: #828282;"
+				>{#if collapsed[comment.id]}[+]{:else}[&ndash;]{/if}</a>
 			</div>
+			{#if !collapsed[comment.id]}
 			<div class="comment-text" class:faded={getPoints(comment) < 1} style="padding-left: 14px;">
 				{#each comment.text.split('\n') as paragraph}
 					{#if paragraph.trim()}
@@ -82,6 +89,7 @@
 					{/if}
 				{/each}
 			</div>
+			{/if}
 		</div>
 	{/each}
 </div>

--- a/tests/audit/audit-mobile-width.spec.ts
+++ b/tests/audit/audit-mobile-width.spec.ts
@@ -28,10 +28,15 @@ const PATHS = [
 	'/best',
 	'/active',
 	'/newcomments',
-	'/lists',
 	'/front',
-	'/guidelines',
-	'/faq',
+	'/asknew',
+	'/shownew',
+	'/showhn',
+	'/bestcomments',
+	'/highlights',
+	'/noobstories',
+	'/noobcomments',
+	'/from',
 	'/login'
 ] as const;
 

--- a/tests/audit/audit-pc-width.spec.ts
+++ b/tests/audit/audit-pc-width.spec.ts
@@ -7,77 +7,104 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const OUT_DIR = path.join(__dirname, 'screenshots');
 
-// 当方は本番 (https://hn.llll-ll.com) を叩く想定だが、本番が落ちている場合は
-// AUDIT_OURS_URL=http://localhost:5173 で dev server に向けることもできる
+// 当方は本番 (https://hn.llll-ll.com) を叩く想定。
+// AUDIT_OURS_URL=http://localhost:5173 で dev server に向けることもできる。
 const OURS_URL = process.env.AUDIT_OURS_URL ?? 'https://hn.llll-ll.com';
+const HN_BASE = 'https://news.ycombinator.com';
 
-const SITES = [
-	{ id: 'ours', baseURL: OURS_URL },
-	{ id: 'hn', baseURL: 'https://news.ycombinator.com' }
-] as const;
+// PC 幅 1280×720 で本家 HN と並べて視覚パリティを検証する。
+// 当方独自のパス (/admin/*, /ipban, /lists, /api-docs, /noprocrast, /search) は
+// 本家に対応が無い、または挙動が大きく異なるため除外。DESIGN.md 準拠は別 Issue (#107) で監査済み。
+const COMMON_PATHS = [
+	'/',
+	'/newest',
+	'/ask',
+	'/show',
+	'/best',
+	'/active',
+	'/newcomments',
+	'/front',
+	'/asknew',
+	'/shownew',
+	'/showhn',
+	'/bestcomments',
+	'/highlights',
+	'/noobstories',
+	'/noobcomments',
+	'/from',
+	'/login'
+];
+
+const HN_ITEM_ID = 1;
+const HN_USER = 'pg';
+const OURS_ITEM_ID = process.env.AUDIT_OURS_ITEM_ID ?? '1';
+const OURS_USER = process.env.AUDIT_OURS_USER ?? 'noroshi';
 
 function ensureOut() {
 	if (!fs.existsSync(OUT_DIR)) fs.mkdirSync(OUT_DIR, { recursive: true });
+}
+
+function pathToFile(p: string): string {
+	return p.replace(/^\//, '').replace(/[/?=&]/g, '_') || 'home';
 }
 
 test.beforeAll(() => {
 	ensureOut();
 });
 
+const SITES = [
+	{ id: 'ours', baseURL: OURS_URL },
+	{ id: 'hn', baseURL: HN_BASE }
+] as const;
+
 for (const site of SITES) {
-	test(`${site.id} /polls full page`, async ({ page }) => {
-		await page.setViewportSize({ width: 1280, height: 720 });
-		await page.goto(`${site.baseURL}/polls`, { waitUntil: 'load' });
-		await page.screenshot({
-			path: path.join(OUT_DIR, `${site.id}-polls.png`),
-			fullPage: true
+	for (const p of COMMON_PATHS) {
+		test(`pc ${site.id} ${p}`, async ({ page }) => {
+			await page.setViewportSize({ width: 1280, height: 720 });
+			const res = await page.goto(`${site.baseURL}${p}`, { waitUntil: 'load' });
+			const fileBase = `pc-${site.id}-${pathToFile(p)}`;
+			await page.screenshot({
+				path: path.join(OUT_DIR, `${fileBase}.png`),
+				fullPage: true
+			});
+			const html = await page.content();
+			fs.writeFileSync(path.join(OUT_DIR, `${fileBase}.html`), html);
+			const metrics = await page.evaluate(() => ({
+				scrollWidth: document.documentElement.scrollWidth,
+				clientWidth: document.documentElement.clientWidth,
+				bodyHeight: document.body.scrollHeight
+			}));
+			fs.writeFileSync(
+				path.join(OUT_DIR, `${fileBase}.report.json`),
+				JSON.stringify({ status: res?.status() ?? null, ...metrics }, null, 2)
+			);
+			console.log(
+				`[pc ${site.id} ${p}] status=${res?.status()} sw=${metrics.scrollWidth} cw=${metrics.clientWidth}`
+			);
 		});
-		const html = await page.content();
-		fs.writeFileSync(path.join(OUT_DIR, `${site.id}-polls.html`), html);
+	}
+
+	test(`pc ${site.id} /item`, async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 720 });
+		const url =
+			site.id === 'hn'
+				? `${site.baseURL}/item?id=${HN_ITEM_ID}`
+				: `${site.baseURL}/item/${OURS_ITEM_ID}`;
+		await page.goto(url, { waitUntil: 'load' });
+		const fileBase = `pc-${site.id}-item`;
+		await page.screenshot({ path: path.join(OUT_DIR, `${fileBase}.png`), fullPage: true });
+		fs.writeFileSync(path.join(OUT_DIR, `${fileBase}.html`), await page.content());
 	});
 
-	test(`${site.id} /newest first story meta`, async ({ page }) => {
+	test(`pc ${site.id} /user`, async ({ page }) => {
 		await page.setViewportSize({ width: 1280, height: 720 });
-		await page.goto(`${site.baseURL}/newest`, { waitUntil: 'load' });
-
-		// 本家HN は .athing + .subtext 構造、当方は .story-item + .story-meta 構造
-		// 両方の場合に対応するため body から first story 周辺を抽出する
-		const fullHtml = await page.content();
-		fs.writeFileSync(path.join(OUT_DIR, `${site.id}-newest.html`), fullHtml);
-
-		// 当方: .story-item の最初の .story-meta
-		// 本家: .athing の直後の .subtext
-		const metaHtml = await page.evaluate(() => {
-			// 本家 HN 構造
-			const subtext = document.querySelector('.subtext');
-			if (subtext) {
-				const athing = subtext.closest('tr')?.previousElementSibling as HTMLElement | null;
-				return {
-					kind: 'hn',
-					athing: athing?.outerHTML ?? null,
-					subtext: subtext.outerHTML
-				};
-			}
-			// 当方 HN-noroshi 構造
-			const item = document.querySelector('.story-item');
-			if (item) {
-				return {
-					kind: 'ours',
-					item: item.outerHTML,
-					meta: item.querySelector('.story-meta')?.outerHTML ?? null
-				};
-			}
-			return { kind: 'unknown' };
-		});
-
-		fs.writeFileSync(
-			path.join(OUT_DIR, `${site.id}-newest-meta.json`),
-			JSON.stringify(metaHtml, null, 2)
-		);
-
-		await page.screenshot({
-			path: path.join(OUT_DIR, `${site.id}-newest.png`),
-			fullPage: false
-		});
+		const url =
+			site.id === 'hn'
+				? `${site.baseURL}/user?id=${HN_USER}`
+				: `${site.baseURL}/user/${OURS_USER}`;
+		await page.goto(url, { waitUntil: 'load' });
+		const fileBase = `pc-${site.id}-user`;
+		await page.screenshot({ path: path.join(OUT_DIR, `${fileBase}.png`), fullPage: true });
+		fs.writeFileSync(path.join(OUT_DIR, `${fileBase}.html`), await page.content());
 	});
 }


### PR DESCRIPTION
## 関連 Issue

closes #73

## 経緯

PR #118 で line-height / mobile font-size を揃えたが /newest しか目視確認していなかった。本 PR では **PC + mobile 両方で全 26 ページ** を本家 HN と並べてスクショ比較し、検出された全差分を修正。

## 全画面比較で検出した差分と対応

### CSS / レイアウト
| 差分 | 修正 |
|---|---|
| mobile で `▲` (votearrow) が HN より小さい | `@media (max-width: 750px)` に `transform: scale(1.3); margin-right: 6px` を追加（HN news.css mobile に一致） |
| コメント左 padding が広い | `/item` の `comment-text/reply/form` の `padding-left: 14px` → `0` |
| /user の about セルが mobile で 80% width 残存 | mobile @media で `max-width: 100%` 上書き |

### nav 強化
| 差分 | 修正 |
|---|---|
| 現在ページが太字でない | `aria-current="page"` + `.active { font-weight: bold }` |
| nav 右端のページ名ラベルが無い | `.hn-header-pagename` に `<span class="topright">` を追加し 21 パスのマッピング |

### ページ別 content
| 差分 | 修正 |
|---|---|
| /best 上部の説明行がない | 「過去48時間で得点の高い投稿。`?h=24` で時間数を変更可」を追加 |
| /show に Launch HN リンクが無い | 説明文に Launch HN リンクを追加 |
| /front 日付ナビが 1 行 | 2 行に分割（日付行 + 移動行） |
| /from 引数なしで /news 表示 | 引数なしで空ページ + 案内文に変更 |
| /user created が ISO `2026-05-06` | 英語ロング `May 6, 2026` 形式に |

### コメント機能
| 差分 | 修正 |
|---|---|
| `[–]` 折りたたみトグルが無い | `/item` + 6 ページ（newcomments/bestcomments/highlights/noobcomments/user comments/search）に追加 |
| コメントメタに `next` / `root` リンクが無い | /item ツリーの DFS 順位で `nextCommentId` / `rootCommentId` を `$derived` 算出して各コメントに表示 |

### バックエンド差別化
| 差分 | 修正 |
|---|---|
| /highlights が bestcomments と同一 | `getHighlightedComments`: `c.points >= 5` AND ストーリー内コメント数 >= 3 で絞る新クエリ追加 |
| /noobcomments | 確認したら既に `getCommentsByNewUsers(db, TWO_WEEKS_MS)` で差別化済み（修正不要） |

### login form 構造変更
| 差分 | 修正 |
|---|---|
| `<table>` レイアウトでラベル右寄せ | inline ラベル形式に変更（HN 準拠）、input 220px |

### topright 重複修正（追加コミット）
- /login /signup /logout のとき topright `login` と header-right の `login` リンクが重複表示
- → 認証系パスは extraToprightMap から除外

## 維持した独自項目（HN との意図的差分）
- site 名「ハッカーのろし」（白文字）— ブランディング
- nav に `jobs` 無し — 当方は jobs 機能を持たない
- footer の `GitHub | Search`（HN は `Security | Legal | Apply to YC | Contact`）— 当方独自
- /showhn は HN は "Unknown."、当方は Show HN ガイドライン — 独自付加価値
- 「Forgot your password?」リンク無し — #90 で email 認証廃止済み

## 監査資料

- `tests/audit/audit-pc-width.spec.ts` を 17 ページ + item + user に拡張（PC 38 テスト）
- `tests/audit/audit-mobile-width.spec.ts` を 17 ページ + item + user に拡張（mobile 38 テスト）
- 4 サブエージェントが PC story-list / PC comment+detail / mobile story-list / mobile comment+detail を視覚比較し、報告に基づき修正

## Test plan

- [x] svelte-check: 0 ERRORS
- [x] vitest: 194 / 194 passed
- [x] audit specs (76 tests) all pass
- [x] PC /newest /login スクショで HN 視覚パリティ確認
- [ ] 本番デプロイ後に hn.llll-ll.com の各ページが視覚的に HN に一致することを目視最終確認