### PR TITLE
fix: seed.sql の password_hash を auth.ts (salt32hex:sha256hex) 形式に修正 (#125)

### DIFF
--- a/db/seed.sql
+++ b/db/seed.sql
@@ -1,6 +1,6 @@
 -- Seed data for local development
--- password is "test1234" for all users (bcrypt hash)
--- $2a$10$K4GzQqBq9LZlh9OvBOE6eOqv7GYFv9HZVq3YR6R0HjKq5AXq5GQSy
+-- password is "test1234" for all users. hash format: src/lib/server/auth.ts (salt32hex:sha256hex)
+-- ddac7a274f5441e1aec447627cccb77e:a7979be7b679ea8949bcf2d340270c78d45ca18e5184da73ff30c3b1d0d89adf
 --
 -- Issue #121: 各タブ・各クエリパラメータ・権限分岐を seed 一発で網羅できるように拡充。
 -- 既存 user id 1-3 / story id 1-6 は維持（既存テストや手動検証手順との互換性のため）。
@@ -11,21 +11,21 @@
 --            6=karma_low, 7=new_user, 8=old_user, 9=deleted_acc
 -- ────────────────────────────────────────────────────────────────────
 INSERT INTO users (username, password_hash, karma, about, is_admin) VALUES
-  ('noroshi', '$2a$10$K4GzQqBq9LZlh9OvBOE6eOqv7GYFv9HZVq3YR6R0HjKq5AXq5GQSy', 100, 'ハッカーのろし管理人', 1),
-  ('tanaka', '$2a$10$K4GzQqBq9LZlh9OvBOE6eOqv7GYFv9HZVq3YR6R0HjKq5AXq5GQSy', 42, 'Rustが好き', 0),
-  ('sato', '$2a$10$K4GzQqBq9LZlh9OvBOE6eOqv7GYFv9HZVq3YR6R0HjKq5AXq5GQSy', 15, 'フロントエンド開発者', 0);
+  ('noroshi', 'ddac7a274f5441e1aec447627cccb77e:a7979be7b679ea8949bcf2d340270c78d45ca18e5184da73ff30c3b1d0d89adf', 100, 'ハッカーのろし管理人', 1),
+  ('tanaka', 'ddac7a274f5441e1aec447627cccb77e:a7979be7b679ea8949bcf2d340270c78d45ca18e5184da73ff30c3b1d0d89adf', 42, 'Rustが好き', 0),
+  ('sato', 'ddac7a274f5441e1aec447627cccb77e:a7979be7b679ea8949bcf2d340270c78d45ca18e5184da73ff30c3b1d0d89adf', 15, 'フロントエンド開発者', 0);
 
 -- karma 階層・期間別ユーザー
 INSERT INTO users (username, password_hash, karma, about, is_admin, created_at) VALUES
-  ('karma_high', '$2a$10$K4GzQqBq9LZlh9OvBOE6eOqv7GYFv9HZVq3YR6R0HjKq5AXq5GQSy', 600, 'downvote 可（karma>=500）', 0, strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-90 days')),
-  ('karma_mid', '$2a$10$K4GzQqBq9LZlh9OvBOE6eOqv7GYFv9HZVq3YR6R0HjKq5AXq5GQSy', 50, 'flag 可（karma>=30、500未満）', 0, strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-60 days')),
-  ('karma_low', '$2a$10$K4GzQqBq9LZlh9OvBOE6eOqv7GYFv9HZVq3YR6R0HjKq5AXq5GQSy', 1, 'まだ権限なし', 0, strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-10 days')),
-  ('new_user', '$2a$10$K4GzQqBq9LZlh9OvBOE6eOqv7GYFv9HZVq3YR6R0HjKq5AXq5GQSy', 2, 'はじめまして', 0, strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-  ('old_user', '$2a$10$K4GzQqBq9LZlh9OvBOE6eOqv7GYFv9HZVq3YR6R0HjKq5AXq5GQSy', 250, '6ヶ月前に登録', 0, strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-180 days'));
+  ('karma_high', 'ddac7a274f5441e1aec447627cccb77e:a7979be7b679ea8949bcf2d340270c78d45ca18e5184da73ff30c3b1d0d89adf', 600, 'downvote 可（karma>=500）', 0, strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-90 days')),
+  ('karma_mid', 'ddac7a274f5441e1aec447627cccb77e:a7979be7b679ea8949bcf2d340270c78d45ca18e5184da73ff30c3b1d0d89adf', 50, 'flag 可（karma>=30、500未満）', 0, strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-60 days')),
+  ('karma_low', 'ddac7a274f5441e1aec447627cccb77e:a7979be7b679ea8949bcf2d340270c78d45ca18e5184da73ff30c3b1d0d89adf', 1, 'まだ権限なし', 0, strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-10 days')),
+  ('new_user', 'ddac7a274f5441e1aec447627cccb77e:a7979be7b679ea8949bcf2d340270c78d45ca18e5184da73ff30c3b1d0d89adf', 2, 'はじめまして', 0, strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+  ('old_user', 'ddac7a274f5441e1aec447627cccb77e:a7979be7b679ea8949bcf2d340270c78d45ca18e5184da73ff30c3b1d0d89adf', 250, '6ヶ月前に登録', 0, strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-180 days'));
 
 -- 削除済みアカウント（[deleted] 表示確認用）
 INSERT INTO users (username, password_hash, karma, about, is_admin, deleted, deleted_at, created_at) VALUES
-  ('deleted_acc', '$2a$10$K4GzQqBq9LZlh9OvBOE6eOqv7GYFv9HZVq3YR6R0HjKq5AXq5GQSy', 5, '', 0, 1, strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-3 days'), strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-30 days'));
+  ('deleted_acc', 'ddac7a274f5441e1aec447627cccb77e:a7979be7b679ea8949bcf2d340270c78d45ca18e5184da73ff30c3b1d0d89adf', 5, '', 0, 1, strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-3 days'), strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-30 days'));
 
 -- ────────────────────────────────────────────────────────────────────
 -- stories（既存 6 + 新規 35 = 41）

--- a/tests/unit/auth.test.ts
+++ b/tests/unit/auth.test.ts
@@ -38,4 +38,14 @@ describe('hashPassword / verifyPassword', () => {
 		const { verifyPassword } = await import('../../src/lib/server/auth');
 		expect(await verifyPassword('any', 'no-colon-here')).toBe(false);
 	});
+
+	// #125: db/seed.sql の固定 hash が "test1234" を verify できることを確認する。
+	// 実装側 (auth.ts) を変えると seed が壊れるリグレッション検出。
+	it('verifies seed.sql password_hash for "test1234"', async () => {
+		const { verifyPassword } = await import('../../src/lib/server/auth');
+		const seedHash =
+			'ddac7a274f5441e1aec447627cccb77e:a7979be7b679ea8949bcf2d340270c78d45ca18e5184da73ff30c3b1d0d89adf';
+		expect(await verifyPassword('test1234', seedHash)).toBe(true);
+		expect(await verifyPassword('wrong', seedHash)).toBe(false);
+	});
 });


### PR DESCRIPTION
## 関連 Issue

closes #125

## 修正内容

\`db/seed.sql\` の \`password_hash\` を旧 bcrypt 形式 (\`\$2a\$10\$...\`) から \`src/lib/server/auth.ts\` の Web Crypto ベース形式 (\`salt32hex:sha256hex\`) に置換。

### 影響
- これまで seed user (noroshi/tanaka/sato/karma_high/karma_mid/karma_low/new_user/old_user) で \`/login\` 試行すると常に "Bad login" で失敗していた
- e2e は \`signupNewUser\` で新規ユーザーを作る方式で回避していたが、seed user 経由テストは不可だった
- 修正後は seed user で \`test1234\` で正常 login 可能

### 生成手順
\`\`\`js
// auth.ts hashPassword と同じロジック
const salt = crypto.randomUUID().replace(/-/g, '');
const hash = sha256hex(salt + 'test1234');
const password_hash = salt + ':' + hash;
\`\`\`

実値（テスト環境のため固定で seed に書き込み）:
\`ddac7a274f5441e1aec447627cccb77e:a7979be7b679ea8949bcf2d340270c78d45ca18e5184da73ff30c3b1d0d89adf\`

## 回帰検出テスト

\`tests/unit/auth.test.ts\` に追加:
- 固定 hash が \`verifyPassword('test1234')\` で true になることを assertion
- auth.ts 変更時に seed が壊れたら検出

## Test plan

- [x] \`npx vitest run tests/unit/auth.test.ts\`: 6 / 6 pass (新規 1 件追加)
- [x] \`npm run db:seed\` 成功
- [ ] dev server で \`noroshi\` / \`test1234\` 手動 login → 200 確認（kako-jun の手で）

## 影響範囲
- \`db/seed.sql\` 単一行（password_hash 列の値のみ、他の seed 内容は不変）
- \`tests/unit/auth.test.ts\` 1 ケース追加