### PR TITLE
docs: kako-jun/hacker-noroshi#132 README を v1 相当に更新 + architecture.md 追従

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,102 @@
 # ハッカーのろし (Hacker Noroshi)
 
-日本の技術者向けリンク共有・議論サイト。[Hacker News](https://news.ycombinator.com) にインスパイアされた日本語コミュニティ。
+日本の技術者向けリンク共有・議論サイト。[Hacker News](https://news.ycombinator.com) の日本語クローン。
 
-**HN** = **H**acker **N**oroshi（Hacker News と同じイニシャル、意図的）
+**HN** = **H**acker **N**oroshi（Hacker News と同じイニシャル、意図的）。
 
 ## URL
 
-https://hn.llll-ll.com (予定)
+https://hn.llll-ll.com
+
+## 趣旨
+
+- 本家 Hacker News を「見た目で区別がつかない」レベルでトレース（`DESIGN.md` / `CLAUDE.md` の方針）
+- 日本人が HN の感覚を練習するための場（英語ラベルにホバーで日本語訳を出す機能は今後追加予定 #133）
+- 完全日本語 UI、ストーリー本文・コメントは日本語前提
+
+## 機能
+
+### 投稿・コンテンツ
+
+- ストーリー投稿（URL or テキスト、type は `story` / `ask` / `show` を自動判定）
+- poll（投票）の投稿（`/newpoll`、選択肢 2-10 個、トグル投票）
+- 編集（投稿・コメント、投稿後 2 時間ウィンドウ）
+- 削除（タイトルが `[deleted]` になり本文が消える）
+- レート制限（投稿 10 分間隔等）
+
+### コメント
+
+- ネストスレッド（深さ無制限）
+- 編集（投稿後 2 時間）
+- 削除
+- 折り畳み（`[-]` / `[+]` トグル、子孫数表示）
+- 親へのリンク（parent / root / next）
+
+### 投票・モデレーション
+
+- upvote
+- downvote（karma 500 以上）
+- flag（karma 30 以上、5 件で dead 自動化）
+- vouch（dead 復活、関連 flags を全削除）
+- hide（自分の一覧から非表示）
+- favorite（お気に入り）
+
+### 一覧・発見
+
+- `/` フロントページ（HN ランキングアルゴリズム）
+- `/newest` 新着順
+- `/best` 高得点
+- `/active` 議論中
+- `/front` 日付別フロントページ
+- `/ask` `/show` Ask HN / Show HN
+- `/asknew` `/shownew` 新着 ask/show
+- `/newcomments` `/bestcomments` `/noobcomments` コメント一覧
+- `/noobstories` 新規ユーザーの投稿
+- `/highlights` ハイライト（全期間の高得点コメント）
+- `/leaders` 高 karma ユーザー
+- `/lists` 一覧へのリンク集
+- `/from?site=domain` ドメイン別投稿
+- `/search` 検索（ストーリー + コメント）
+
+### ユーザー
+
+- 登録 / ログイン / ログアウト
+- プロフィール（`/user/[id]`）、submissions / comments / favorites / hidden 一覧
+- アカウント削除（投稿・コメントは残るが username が `[deleted]` 化）
+- ユーザー名変更（90 日クールダウン、旧名からのリダイレクト）
+
+### 公開 API（#131、v1 で追加）
+
+- `/api/v0/topstories.json` 等 6 listings
+- `/api/v0/item/{id}.json`、`/api/v0/user/{username}.json`
+- 未認証、CORS `*`、[HackerNews/API](https://github.com/HackerNews/API) 互換
+- 詳細: `/api-docs` ページ
+
+### その他
+
+- RSS フィード（`/rss`）
+- Turnstile（bot 対策、login / signup / submit）
+- admin / IP ban、セルフサービス unban
+- noprocrast
 
 ## 技術スタック
 
-- **SvelteKit** — フルスタックフレームワーク
-- **Cloudflare Pages + Workers** — ホスティング
-- **Cloudflare D1** — SQLite ベースのデータベース
+| 層 | 技術 |
+|---|---|
+| Framework | SvelteKit (Svelte 5) |
+| Hosting | Cloudflare Pages + Workers |
+| DB | Cloudflare D1 (SQLite) |
+| Auth | 自前（salt + sha256 + セッション Cookie） |
+| Style | 素の CSS（pt 単位、Verdana、フラット） |
+| Test | Vitest (unit) + Playwright (E2E) |
 
 ## ローカル開発
 
 ```bash
 npm install
-npm run db:init    # D1ローカルDBにスキーマ作成
+npm run db:init    # D1 ローカル DB にスキーマ作成
 npm run db:seed    # テストデータ投入
-npm run dev        # 開発サーバー起動
+npm run dev        # 開発サーバー起動 (http://localhost:5173)
 ```
 
 wrangler 経由で D1 バインディングが必要な場合:
@@ -29,6 +105,8 @@ wrangler 経由で D1 バインディングが必要な場合:
 npx wrangler pages dev -- npm run dev
 ```
 
+公開 API は `/api/v0/*.json` で叩ける（例: `curl http://localhost:5173/api/v0/topstories.json`）。
+
 ## デプロイ
 
 ```bash
@@ -36,21 +114,35 @@ npm run build
 wrangler pages deploy
 ```
 
-## DB操作（リモート）
+## DB 操作（リモート）
 
 ```bash
 wrangler d1 execute hacker-noroshi-db --remote --file=db/schema.sql
 wrangler d1 execute hacker-noroshi-db --remote --file=db/seed.sql
 ```
 
-## 機能
+## テスト
 
-- 投稿（URLリンク / テキスト）
-- コメント（ネストスレッド）
-- 投票（upvote）
-- ユーザー登録・ログイン
-- ランキング（HN アルゴリズム準拠）
-- Ask HN / Show HN カテゴリ
+```bash
+npm test               # Vitest unit
+npm run test:e2e       # Playwright E2E (要 dev サーバー)
+npm run test:e2e:ui    # Playwright UI モード
+```
+
+## ドキュメント
+
+| ファイル | 内容 |
+|---|---|
+| [docs/spec.md](docs/spec.md) | 機能仕様（投稿・コメント・投票・認証・編集・API） |
+| [DESIGN.md](DESIGN.md) | デザインシステム（カラーパレット・タイポグラフィ・レイアウト） |
+| [docs/architecture.md](docs/architecture.md) | 技術構成・ルート・DB スキーマ・関数一覧 |
+| [docs/operations.md](docs/operations.md) | デプロイ・DB 操作・運用手順 |
+| [docs/testing.md](docs/testing.md) | テスト構成・実行方法 |
+
+## Issue / Contributing
+
+バグ・要望は GitHub Issues へ:
+https://github.com/kako-jun/hacker-noroshi/issues
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ https://hn.llll-ll.com
 - poll（投票）の投稿（`/newpoll`、選択肢 2-10 個、トグル投票）
 - 編集（投稿・コメント、投稿後 2 時間ウィンドウ）
 - 削除（タイトルが `[deleted]` になり本文が消える）
-- レート制限（投稿 10 分間隔等）
+- レート制限（ストーリー投稿は 10 分間隔等）
 
 ### コメント
 
@@ -67,8 +67,8 @@ https://hn.llll-ll.com
 
 ### 公開 API（#131、v1 で追加）
 
-- `/api/v0/topstories.json` 等 6 listings
-- `/api/v0/item/{id}.json`、`/api/v0/user/{username}.json`
+- listings 6 種: `/api/v0/{topstories,newstories,beststories,askstories,showstories,activestories}.json`
+- 詳細: `/api/v0/item/{id}.json`、`/api/v0/user/{username}.json`
 - 未認証、CORS `*`、[HackerNews/API](https://github.com/HackerNews/API) 互換
 - 詳細: `/api-docs` ページ
 
@@ -76,8 +76,9 @@ https://hn.llll-ll.com
 
 - RSS フィード（`/rss`）
 - Turnstile（bot 対策、login / signup / submit）
-- admin / IP ban、セルフサービス unban
-- noprocrast
+- 管理者画面 / IP ban
+- IP ban のセルフ unban（Turnstile 経由）
+- noprocrast（集中モード — 設定時間内はアクセスを制限）
 
 ## 技術スタック
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,6 +50,8 @@ hacker-noroshi/
 │   │       ├── flag/         # フラグ API（karma>=30、5件で dead）
 │   │       ├── vouch/        # Vouch API（dead 復活、flags 削除）
 │   │       └── v0/           # 公開 API v0（HN 互換、未認証、#131）
+│   │           # 各 *.json はディレクトリで、配下に +server.ts を持つ。
+│   │           # SvelteKit の規約により URL は末尾 /.json となる。
 │   │           ├── topstories.json/    # フロントページ id 配列
 │   │           ├── newstories.json/    # 新着 id 配列
 │   │           ├── beststories.json/   # 高得点 id 配列
@@ -89,7 +91,7 @@ hacker-noroshi/
 |---|---|---|
 | id | INTEGER PK | autoincrement |
 | username | TEXT UNIQUE | 3-15文字、英数字+アンダースコア+ハイフン |
-| password_hash | TEXT | bcrypt |
+| password_hash | TEXT | `salt32hex:sha256hex` 形式（src/lib/server/auth.ts） |
 | karma | INTEGER | デフォルト 0 |
 | about | TEXT | 自己紹介（任意） |
 | delay | INTEGER | コメント遅延（0-10分、デフォルト 0） |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@
 | フレームワーク | SvelteKit (Svelte 5) |
 | デプロイ | Cloudflare Pages + Workers |
 | DB | Cloudflare D1 (SQLite) |
-| 認証 | 自前（bcrypt + セッション Cookie） |
+| 認証 | 自前（salt + sha256 ハッシュ + セッション Cookie。実装は `src/lib/server/auth.ts`） |
 | スタイル | 素の CSS（フレームワーク不使用） |
 
 ## ディレクトリ構成
@@ -48,11 +48,23 @@ hacker-noroshi/
 │   │       ├── favorite/     # お気に入り API
 │   │       ├── hide/         # 非表示 API
 │   │       ├── flag/         # フラグ API（karma>=30、5件で dead）
-│   │       └── vouch/        # Vouch API（dead 復活、flags 削除）
+│   │       ├── vouch/        # Vouch API（dead 復活、flags 削除）
+│   │       └── v0/           # 公開 API v0（HN 互換、未認証、#131）
+│   │           ├── topstories.json/    # フロントページ id 配列
+│   │           ├── newstories.json/    # 新着 id 配列
+│   │           ├── beststories.json/   # 高得点 id 配列
+│   │           ├── askstories.json/    # ask id 配列
+│   │           ├── showstories.json/   # show id 配列
+│   │           ├── activestories.json/ # active id 配列（HN 拡張）
+│   │           ├── item/[id].json/     # story / comment 詳細
+│   │           └── user/[username].json/ # ユーザープロフィール
 │   ├── lib/
 │   │   ├── server/
 │   │   │   ├── db.ts         # D1 データアクセス関数
-│   │   │   └── auth.ts       # パスワードハッシュ・セッション管理
+│   │   │   ├── auth.ts       # パスワードハッシュ・セッション管理
+│   │   │   ├── admin.ts      # 管理者向けユーティリティ
+│   │   │   ├── api.ts        # 公開 API v0 共通レスポンス + serializer (#131)
+│   │   │   └── userRoute.ts  # ユーザールートの共通ロジック
 │   │   ├── format.ts         # テキストフォーマット（URL自動リンク、*イタリック*）
 │   │   └── ranking.ts        # timeAgo, extractDomain 等のユーティリティ
 │   ├── app.css               # グローバル CSS
@@ -271,13 +283,21 @@ env: `TURNSTILE_SITE_KEY`（public）と `TURNSTILE_SECRET_KEY`（secret）。
 | `/noprocrast` | noprocrast ブロックページ（残り時間表示） |
 | `/search` | 検索（?q=キーワード&type=all\|stories\|comments&p=ページ） |
 | `/from` | ドメイン別投稿一覧（?site=example.com、/item の past リンクから遷移） |
-| `/api-docs` | APIドキュメント（準備中） |
+| `/api-docs` | 公開 API のドキュメント（実装済みエンドポイント一覧、フィールドリファレンス、CORS / Cache 方針） |
 | `/rss` | RSS 2.0 フィード（トップページのストーリー30件） |
 | `/api/vote` | 投票 API エンドポイント |
 | `/api/favorite` | お気に入り API エンドポイント |
 | `/api/hide` | 非表示 API エンドポイント |
 | `/api/flag` | フラグ API エンドポイント（karma>=30、トグル、5件で dead 自動化） |
 | `/api/vouch` | Vouch API エンドポイント（dead アイテムを復活、関連 flags を全削除） |
+| `/api/v0/topstories.json` | 公開 API: フロントページ id 配列（HN 互換） |
+| `/api/v0/newstories.json` | 公開 API: 新着 id 配列 |
+| `/api/v0/beststories.json` | 公開 API: 高得点 id 配列 |
+| `/api/v0/askstories.json` | 公開 API: ask id 配列 |
+| `/api/v0/showstories.json` | 公開 API: show id 配列 |
+| `/api/v0/activestories.json` | 公開 API: active id 配列（HN 拡張） |
+| `/api/v0/item/[id].json` | 公開 API: story / comment 詳細（kids は immediate children） |
+| `/api/v0/user/[username].json` | 公開 API: ユーザープロフィール（lightweight、submitted 含まず） |
 
 ## DB アクセス関数 (src/lib/server/db.ts)
 


### PR DESCRIPTION
## 関連 Issue
closes #132

## 変更内容

### README.md 全面刷新

- URL から「予定」削除（本番運用中）
- 機能リストを v1 相当に拡充: 投稿/poll/編集/削除、コメント、投票・モデレーション (upvote / downvote / flag / vouch / hide / favorite)、一覧・発見系 (newest / best / active / front / ask / show / asknew / shownew / newcomments / bestcomments / noobcomments / noobstories / highlights / leaders / lists / from / search)、ユーザー機能、公開 API v0 (#131)、その他 (RSS / Turnstile / admin / IP ban)
- 技術スタック表（Auth は salt+sha256、実装と整合）
- ローカル開発・デプロイ・DB 操作・テストの手順
- `docs/` への参照リンク
- Issue / Contributing 案内

### docs/architecture.md 追従

- L11 認証: `bcrypt` → `salt + sha256` に修正（実装と整合）
- ディレクトリツリーに `src/lib/server/{admin,api,userRoute}.ts` と `api/v0/` 配下 8 ルートを追加
- ルート表に `/api/v0/*` エンドポイント 8 件を追加
- `/api-docs` の説明を「（準備中）」から「公開 API のドキュメント（実装済みエンドポイント一覧、フィールドリファレンス、CORS / Cache 方針）」に更新

### スコープ外（やっていないこと）

- **LICENSE ファイル追加なし**: kako-jun の全 repos 横断のフリーザ作業として別途実施する方針。README の「## ライセンス / MIT」記載は維持
- **スクリーンショット追加なし**: 別 Issue で後日対応
- **docs/spec.md / docs/operations.md / docs/testing.md は触らない**: spec.md は #131 で更新済、他は古い記述見当たらず

## 検証

ドキュメントのみの変更。コードに変化なし、テストも変更なし。