### PR TITLE
fix: 本家HN視覚パリティの微差（ヘッダ/フッタ・PC/スマホ）（#144）

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -27,12 +27,12 @@ Hardcoded CSS values. No variables, no tokens.
 | Color     | Hex       | Usage                              |
 | --------- | --------- | ---------------------------------- |
 | Orange    | `#ff6600` | Header bg, voted indicator (up/down), hover |
-| Cream     | `#f6f6ef` | Page background                    |
+| Cream     | `#f6f6ef` | Centered container (85% / #hnmain) background |
 | Black     | `#000000` | Primary text, titles               |
 | Gray      | `#828282` | Meta text, timestamps, visited links, faded comments (downvoted) |
 | Light gray | `#9a9a9a` | Inactive upvote arrow              |
 | Red       | `#ff0000` | Error messages                     |
-| White     | `#ffffff` | Header text, logo border           |
+| White     | `#ffffff` | Header text, logo border, body/outer frame (PC: shown around the 85% container) |
 
 Links: `#000000` (unvisited), `#828282` (visited). Hover: underline only.
 

--- a/src/app.css
+++ b/src/app.css
@@ -51,7 +51,9 @@ a:hover {
 	}
 
 	.hn-header-left {
-		flex-wrap: wrap;
+		/* ロゴと titlenav は横並びのまま（折り返さない）。折り返しは titlenav 内部で起こし、
+		   nav がロゴの右側に留まるようにする（#144）。 */
+		flex-wrap: nowrap;
 		flex: 1 1 auto;
 	}
 
@@ -86,8 +88,8 @@ a:hover {
 	}
 
 	.hn-footer-search input {
+		/* スマホでは検索ボックスを横いっぱいに（本家より狭い 200px 上限を撤去・#144）。 */
 		width: 100%;
-		max-width: 200px;
 	}
 
 	/* Remove 40px form indent on narrow viewports — at 375px that ate
@@ -197,6 +199,17 @@ a:hover {
 	align-items: center;
 	gap: 0;
 	flex: 1;
+}
+
+/* サイト名＋nav を1ブロックにして、ロゴの右側で内部折り返しさせる（本家HNのテーブルセル相当・#144）。
+   スマホ幅で nav が2行目に回り込んでもロゴより左には来ず、ロゴは2行の縦中央になる
+   （.hn-header-left は align-items:center なのでロゴが titlenav の高さに対して中央寄せ）。 */
+.hn-header-titlenav {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	flex: 1 1 auto;
+	min-width: 0;
 }
 
 .hn-header-left .hn-header-site-name {

--- a/src/app.css
+++ b/src/app.css
@@ -14,7 +14,9 @@ body {
 	font-family: Verdana, Geneva, sans-serif;
 	font-size: 10pt;
 	color: #828282;
-	background-color: #f6f6ef;
+	/* 本家 HN は body=白＋中央コンテナ(#hnmain)=cream の二層。PC幅で 85% コンテナの外側が白フレームになる
+	   （スマホ幅は .hn-page が 100% で白は見えない）。コンテナ色は .hn-page が #f6f6ef で持つ（#144）。 */
+	background-color: #ffffff;
 }
 
 a {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -85,6 +85,7 @@
 	<header class="hn-header">
 		<div class="hn-header-left">
 			<a href="/" class="hn-header-logo"><img src="/icon-header.webp" alt="ハッカーのろし" width="18" height="18" /></a>
+			<div class="hn-header-titlenav">
 			<a href="/" class="hn-header-site-name">ハッカーのろし</a>
 			<nav class="hn-header-nav">
 				{#each navItems as item, i (item.href)}
@@ -99,6 +100,7 @@
 					>
 				{/each}
 			</nav>
+			</div>
 		</div>
 		<div class="hn-header-pagename">
 			{#if currentTopright(page.url.pathname)}


### PR DESCRIPTION
Closes #144

kako-jun の本家 news.ycombinator.com との実機比較で見つかった微差を詰めた。HNコアの忠実度（アシスト #140 とは別）。**検証は getBoundingClientRect / elementFromPoint で実測**（headless スクショはこの環境で不安定だったため、座標と要素ヒットで確認）。

## 修正
- **PC外側の白フレーム**: `body` 背景を cream→白に。本家は body=白＋中央 `#hnmain`=cream の二層。実測で `.hn-page`=85%中央(left83/width935)・`elementFromPoint(5,20)`=BODY白・`(1090,20)`=BODY白＝外側が白フレーム。`.hn-page` は cream のまま。
  - ※「ヘッダ上の隙間」は `header.top=0`（天井ぴったり）で再現せず＝実体は外側フレームの cream で、それを白にした。
- **スマホのヘッダ折り返し**: サイト名+nav を `.hn-header-titlenav` で包み、スマホ幅で `.hn-header-left` を nowrap・titlenav を内部折り返しに。nav が2行目でも**ロゴの右(left26)に留まり**、ロゴは2行の縦中央(top10)。本家のセル配置相当。
- **スマホ検索ボックス**: フッタ検索の 200px 上限を撤去し横いっぱいに。
- **フッタリンク色**: 計測の結果 **既に #828282（本家グレー）** だったため変更なし（正しいものは触らない）。

## 検証
- `npm run check` 0 errors。`locale-switch` e2e 3 緑（ヘッダ markup 変更の退行なし）。
- PC は logo→name→nav 一列のまま（崩れなし・実測）。スマホは実描画でもロゴ右インデントを確認。

## 関連
#73（視覚パリティ達成）の follow-up。アシスト #140(PR #142) とは独立。