### PR TITLE
fix: #149 ログアウトを data-sveltekit-reload でフル遷移にしヘッダ即更新（+ hover 誤ログアウト防止）

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -124,7 +124,12 @@
 			<a href={localeToggleHref(data.locale, page.url.pathname, page.url.search)}>{l('lang')}</a> |
 			{#if data.user}
 				<a href="/user/{data.user.username}">{data.user.username}</a> ({data.user.karma}) |
-				<a href="/logout" title={tip('logout')}>{l('logout')}</a>
+				<!-- フル遷移でログアウトする（data-sveltekit-reload）。SPA だと /logout の load が session を消しても
+				     layout の cookie 読みは依存追跡外で再実行されず、ヘッダが「ログイン中」のまま残る（リロードまで）。
+				     さらに body の preload-data="hover" で hover すると /logout load が先読みされ session が消える事故も防ぐ。 -->
+				<a href="/logout" title={tip('logout')} data-sveltekit-reload data-sveltekit-preload-data="off"
+					>{l('logout')}</a
+				>
 			{:else}
 				<a href="/login" title={tip('login')}>{l('login')}</a>
 			{/if}

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -8,6 +8,9 @@ test.describe('auth', () => {
 
 		// Signup
 		await page.goto('/login');
+		// hydration 待ち: enhance 装着前に click するとネイティブ submit で JSON が表示され navigation が
+		// 止まる既知の flake（helpers.signupNewUser と同じガード）。
+		await page.waitForLoadState('networkidle');
 		const signupForm = page.locator('form[action="?/signup"]');
 		await signupForm.locator('input[name="username"]').fill(username);
 		await signupForm.locator('input[name="password"]').fill(password);
@@ -17,12 +20,14 @@ test.describe('auth', () => {
 		]);
 		await expect(page.locator(`a[href="/user/${username}"]`)).toBeVisible();
 
-		// Logout
-		await page.click('a[href="/logout"]');
+		// Logout。data-sveltekit-reload でフル遷移し、ヘッダが即ログアウト表示に更新される
+		// （SPA だと layout の cookie 読みが再実行されず「ログイン中」が残る回帰を防ぐ）。
+		await Promise.all([page.waitForURL('/'), page.click('a[href="/logout"]')]);
 		await expect(page.locator('a[href="/login"]')).toBeVisible();
 
 		// Login again with the same credentials
 		await page.goto('/login');
+		await page.waitForLoadState('networkidle');
 		const loginForm = page.locator('form[action="?/login"]');
 		await loginForm.locator('input[name="username"]').fill(username);
 		await loginForm.locator('input[name="password"]').fill(password);


### PR DESCRIPTION
Closes #149。#148（#147 リファクタ）の実機レビュー中に発見した pre-existing バグ。独立。

## 症状（本番 hn.llll-ll.com で再現）
logout を SPA クリックしても**ヘッダがログイン中のまま残り、リロードまでログアウト表示にならない**。サーバー側 session は消えている（ハードリロードで確認）。

## 原因
`/logout` GET load が session を消すが、`+layout.server.ts` の `cookies.get('session')` は SvelteKit の依存追跡外で、`/` へ戻る際 layout load が再実行されず `data.user` がキャッシュされたまま。加えて `<body data-sveltekit-preload-data="hover">` で **logout を hover すると load 先読みで session が消える**潜在事故もあった。

## 修正
logout リンクに `data-sveltekit-reload`（クリック時フル遷移＝サーバーがヘッダ再描画）+ `data-sveltekit-preload-data="off"`（hover 先読み無効）。本家 HN も logout はフル遷移なので忠実。

## 検証
- 実機: クリックで即ヘッダがログアウト表示・hover で誤ログアウトしないことを確認。
- `auth.spec` 6/6 安定（signup/login の hydration ガード + logout フル遷移待ちを追加）。型0。

将来はより厳密に logout を POST フォームアクション化が正道（CSRF/プリフェッチ耐性）。本 PR は最小修正。