### PR TITLE
refactor: #151 user の submissions/favorites を StoryList に集約（canonical row 化）

### DIFF
--- a/src/routes/user/[id]/favorites/+page.server.ts
+++ b/src/routes/user/[id]/favorites/+page.server.ts
@@ -1,5 +1,11 @@
 import type { PageServerLoad } from './$types';
-import { getDB, getFavoriteStoriesByUserId, getVotedStoryIds, getFlaggedItemIds } from '$lib/server/db';
+import {
+	getDB,
+	getFavoriteStoriesByUserId,
+	getVotedStoryIds,
+	getFlaggedItemIds,
+	getHiddenStoryIds
+} from '$lib/server/db';
 import { resolveUserOrRedirect } from '$lib/server/userRoute';
 
 export const load: PageServerLoad = async ({ params, url, platform, locals }) => {
@@ -18,17 +24,22 @@ export const load: PageServerLoad = async ({ params, url, platform, locals }) =>
 
 	let votedIds: Set<number> = new Set();
 	let flaggedIds: Set<number> = new Set();
+	let visible = favorites;
 	if (locals.user) {
-		[votedIds, flaggedIds] = await Promise.all([
+		let hiddenIds: Set<number>;
+		[votedIds, flaggedIds, hiddenIds] = await Promise.all([
 			getVotedStoryIds(db, locals.user.id, favorites.map((s) => s.id)),
-			getFlaggedItemIds(db, locals.user.id, favorites.map((s) => s.id), 'story')
+			getFlaggedItemIds(db, locals.user.id, favorites.map((s) => s.id), 'story'),
+			getHiddenStoryIds(db, locals.user.id)
 		]);
+		// canonical row の hide を永続させる（さもないと hide してもリロードで復活する・#152 レビュー）。
+		visible = favorites.filter((s) => !hiddenIds.has(s.id));
 	}
 
 	return {
 		userDeleted: user.deleted,
 		username: user.username,
-		favorites,
+		favorites: visible,
 		votedIds: Array.from(votedIds),
 		flaggedIds: Array.from(flaggedIds),
 		page

--- a/src/routes/user/[id]/favorites/+page.svelte
+++ b/src/routes/user/[id]/favorites/+page.svelte
@@ -1,132 +1,23 @@
 <script lang="ts">
-	import { FLAG_KARMA_THRESHOLD } from '$lib/constants';
-	import { tooltipJa } from '$lib/i18n';
-	import { displayUsername } from '$lib/format';
-	import { timeAgo, extractDomain, isNewUser } from '$lib/ranking';
+	import StoryList from '$lib/components/StoryList.svelte';
 
 	let { data } = $props();
-	let votedIds = $derived(new Set(data.votedIds));
-	let flaggedIds = $derived(new Set(data.flaggedIds ?? []));
-	let localVotedIds = $state<Set<number> | null>(null);
-	let localPoints = $state<Record<number, number>>({});
-	let localFlaggedIds = $state<Set<number> | null>(null);
-	let localFlagCounts = $state<Record<number, number>>({});
-
-	function getVotedIds(): Set<number> {
-		return localVotedIds ?? votedIds;
-	}
-
-	function getFlaggedIds(): Set<number> {
-		return localFlaggedIds ?? flaggedIds;
-	}
-
-	function getFlagCount(story: { id: number; flag_count?: number }): number {
-		return localFlagCounts[story.id] ?? story.flag_count ?? 0;
-	}
-
-	function getPoints(story: { id: number; points: number }): number {
-		return localPoints[story.id] ?? story.points;
-	}
-
-	function canFlag(story: { user_id: number }): boolean {
-		return !!data.user && data.user.karma >= FLAG_KARMA_THRESHOLD && story.user_id !== data.user.id;
-	}
-
-	async function flag(storyId: number) {
-		if (!data.user) {
-			window.location.href = '/login';
-			return;
-		}
-		const res = await fetch('/api/flag', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
-		});
-		if (res.ok) {
-			const result: { flagged: boolean; flagCount: number } = await res.json();
-			const next = new Set(getFlaggedIds());
-			if (result.flagged) next.add(storyId);
-			else next.delete(storyId);
-			localFlaggedIds = next;
-			localFlagCounts = { ...localFlagCounts, [storyId]: result.flagCount };
-		} else if (res.status === 403) {
-			const result = (await res.json()) as { error?: string };
-			alert(result.error || 'Permission denied');
-		}
-	}
-
-	async function vote(storyId: number) {
-		if (!data.user) {
-			window.location.href = '/login';
-			return;
-		}
-		const res = await fetch('/api/vote', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
-		});
-		if (res.ok) {
-			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
-			localPoints = { ...localPoints, [storyId]: result.points };
-			const next = new Set(getVotedIds());
-			if (result.voteState === 'up') {
-				next.add(storyId);
-			} else {
-				next.delete(storyId);
-			}
-			localVotedIds = next;
-		}
-	}
 </script>
 
 <svelte:head>
 	<title>{data.userDeleted ? "[deleted]" : data.username}'s favorites | ハッカーのろし</title>
 </svelte:head>
 
-<div class="story-list" style="padding-left: 40px;">
-	{#each data.favorites as story, i}
-		<div class="story-item">
-			<span class="story-rank">{(data.page - 1) * 30 + i + 1}.</span>
-			<span class="story-vote">
-				<button
-					class="upvote"
-					class:voted={getVotedIds().has(story.id)}
-					onclick={() => vote(story.id)}
-					aria-label="upvote"
-				>
-					&#9650;
-				</button>
-			</span>
-			<div class="story-content" class:faded={story.dead === 1}>
-				<div class="story-title-line">
-					{#if story.url}
-						<a href={story.url} class="story-title">{story.title}</a>
-						<span class="story-domain">({extractDomain(story.url)})</span>
-					{:else}
-						<a href="/item/{story.id}" class="story-title">{story.title}</a>
-					{/if}
-					{#if story.type === 'poll'} <span class="story-tag">[poll]</span>{/if}
-					{#if getFlagCount(story) > 0} <span class="story-tag">[flagged]</span>{/if}
-					{#if story.dead === 1} <span class="story-tag">[dead]</span>{/if}
-				</div>
-				<div class="story-meta">
-					{getPoints(story)} point{getPoints(story) !== 1 ? 's' : ''} by
-					<a href="/user/{story.username}" style={isNewUser(story.user_created_at) ? 'color: #3c963c;' : ''}>{displayUsername({ username: story.username, deleted: story.user_deleted })}</a>
-					<a href="/item/{story.id}">{timeAgo(story.created_at)}</a> |
-					<a href="/item/{story.id}"
-						>{story.comment_count} comment{story.comment_count !== 1 ? 's' : ''}</a
-					>
-					{#if canFlag(story)}
-						| <a href="#flag" onclick={(e) => { e.preventDefault(); flag(story.id); }}>{getFlaggedIds().has(story.id) ? 'un-flag' : 'flag'}</a>
-					{/if}
-				</div>
-			</div>
-		</div>
-	{/each}
+<!-- 行は共通ラッパ StoryList に集約（#151）。プロフィール下に揃える 40px インデントは据え置き。 -->
+<div style="padding-left: 40px;">
+	<StoryList
+		stories={data.favorites}
+		user={data.user}
+		votedIds={data.votedIds}
+		flaggedIds={data.flaggedIds}
+		rankStart={(data.page - 1) * 30}
+		moreHref={data.favorites.length === 30
+			? `/user/${data.username}/favorites?p=${data.page + 1}`
+			: null}
+	/>
 </div>
-
-{#if data.favorites.length === 30}
-	<div class="more-link">
-		<a href="/user/{data.username}/favorites?p={data.page + 1}" title={tooltipJa('More')}>More</a>
-	</div>
-{/if}

--- a/src/routes/user/[id]/hidden/+page.svelte
+++ b/src/routes/user/[id]/hidden/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	// このページは submissions/favorites と違い StoryList/StoryListItem に寄せていない（#151）。
+	// hidden を「除外せず表示」し各行に hide でなく un-hide を出す逆セマンティクスで、canonical row に嵌まらないため。
 	import { FLAG_KARMA_THRESHOLD } from '$lib/constants';
 	import { tooltipJa } from '$lib/i18n';
 	import { displayUsername } from '$lib/format';

--- a/src/routes/user/[id]/submissions/+page.server.ts
+++ b/src/routes/user/[id]/submissions/+page.server.ts
@@ -1,5 +1,11 @@
 import type { PageServerLoad } from './$types';
-import { getDB, getStoriesByUserId, getVotedStoryIds, getFlaggedItemIds } from '$lib/server/db';
+import {
+	getDB,
+	getStoriesByUserId,
+	getVotedStoryIds,
+	getFlaggedItemIds,
+	getHiddenStoryIds
+} from '$lib/server/db';
 import { resolveUserOrRedirect } from '$lib/server/userRoute';
 
 export const load: PageServerLoad = async ({ params, url, platform, locals }) => {
@@ -14,17 +20,22 @@ export const load: PageServerLoad = async ({ params, url, platform, locals }) =>
 
 	let votedIds: Set<number> = new Set();
 	let flaggedIds: Set<number> = new Set();
+	let visible = submissions;
 	if (locals.user) {
-		[votedIds, flaggedIds] = await Promise.all([
+		let hiddenIds: Set<number>;
+		[votedIds, flaggedIds, hiddenIds] = await Promise.all([
 			getVotedStoryIds(db, locals.user.id, submissions.map((s) => s.id)),
-			getFlaggedItemIds(db, locals.user.id, submissions.map((s) => s.id), 'story')
+			getFlaggedItemIds(db, locals.user.id, submissions.map((s) => s.id), 'story'),
+			getHiddenStoryIds(db, locals.user.id)
 		]);
+		// canonical row の hide を永続させる（list ページ同様サーバー側で除外。さもないと hide してもリロードで復活する・#152 レビュー）。
+		visible = submissions.filter((s) => !hiddenIds.has(s.id));
 	}
 
 	return {
 		userDeleted: user.deleted,
 		username: user.username,
-		submissions,
+		submissions: visible,
 		votedIds: Array.from(votedIds),
 		flaggedIds: Array.from(flaggedIds),
 		page

--- a/src/routes/user/[id]/submissions/+page.svelte
+++ b/src/routes/user/[id]/submissions/+page.svelte
@@ -1,132 +1,23 @@
 <script lang="ts">
-	import { FLAG_KARMA_THRESHOLD } from '$lib/constants';
-	import { tooltipJa } from '$lib/i18n';
-	import { displayUsername } from '$lib/format';
-	import { timeAgo, extractDomain, isNewUser } from '$lib/ranking';
+	import StoryList from '$lib/components/StoryList.svelte';
 
 	let { data } = $props();
-	let votedIds = $derived(new Set(data.votedIds));
-	let flaggedIds = $derived(new Set(data.flaggedIds ?? []));
-	let localVotedIds = $state<Set<number> | null>(null);
-	let localPoints = $state<Record<number, number>>({});
-	let localFlaggedIds = $state<Set<number> | null>(null);
-	let localFlagCounts = $state<Record<number, number>>({});
-
-	function getVotedIds(): Set<number> {
-		return localVotedIds ?? votedIds;
-	}
-
-	function getFlaggedIds(): Set<number> {
-		return localFlaggedIds ?? flaggedIds;
-	}
-
-	function getFlagCount(story: { id: number; flag_count?: number }): number {
-		return localFlagCounts[story.id] ?? story.flag_count ?? 0;
-	}
-
-	function getPoints(story: { id: number; points: number }): number {
-		return localPoints[story.id] ?? story.points;
-	}
-
-	function canFlag(story: { user_id: number }): boolean {
-		return !!data.user && data.user.karma >= FLAG_KARMA_THRESHOLD && story.user_id !== data.user.id;
-	}
-
-	async function flag(storyId: number) {
-		if (!data.user) {
-			window.location.href = '/login';
-			return;
-		}
-		const res = await fetch('/api/flag', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
-		});
-		if (res.ok) {
-			const result: { flagged: boolean; flagCount: number } = await res.json();
-			const next = new Set(getFlaggedIds());
-			if (result.flagged) next.add(storyId);
-			else next.delete(storyId);
-			localFlaggedIds = next;
-			localFlagCounts = { ...localFlagCounts, [storyId]: result.flagCount };
-		} else if (res.status === 403) {
-			const result = (await res.json()) as { error?: string };
-			alert(result.error || 'Permission denied');
-		}
-	}
-
-	async function vote(storyId: number) {
-		if (!data.user) {
-			window.location.href = '/login';
-			return;
-		}
-		const res = await fetch('/api/vote', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
-		});
-		if (res.ok) {
-			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
-			localPoints = { ...localPoints, [storyId]: result.points };
-			const next = new Set(getVotedIds());
-			if (result.voteState === 'up') {
-				next.add(storyId);
-			} else {
-				next.delete(storyId);
-			}
-			localVotedIds = next;
-		}
-	}
 </script>
 
 <svelte:head>
 	<title>{data.userDeleted ? "[deleted]" : data.username}'s submissions | ハッカーのろし</title>
 </svelte:head>
 
-<div class="story-list" style="padding-left: 40px;">
-	{#each data.submissions as story, i}
-		<div class="story-item">
-			<span class="story-rank">{(data.page - 1) * 30 + i + 1}.</span>
-			<span class="story-vote">
-				<button
-					class="upvote"
-					class:voted={getVotedIds().has(story.id)}
-					onclick={() => vote(story.id)}
-					aria-label="upvote"
-				>
-					&#9650;
-				</button>
-			</span>
-			<div class="story-content" class:faded={story.dead === 1}>
-				<div class="story-title-line">
-					{#if story.url}
-						<a href={story.url} class="story-title">{story.title}</a>
-						<span class="story-domain">({extractDomain(story.url)})</span>
-					{:else}
-						<a href="/item/{story.id}" class="story-title">{story.title}</a>
-					{/if}
-					{#if story.type === 'poll'} <span class="story-tag">[poll]</span>{/if}
-					{#if getFlagCount(story) > 0} <span class="story-tag">[flagged]</span>{/if}
-					{#if story.dead === 1} <span class="story-tag">[dead]</span>{/if}
-				</div>
-				<div class="story-meta">
-					{getPoints(story)} point{getPoints(story) !== 1 ? 's' : ''} by
-					<a href="/user/{story.username}" style={isNewUser(story.user_created_at) ? 'color: #3c963c;' : ''}>{displayUsername({ username: story.username, deleted: story.user_deleted })}</a>
-					<a href="/item/{story.id}">{timeAgo(story.created_at)}</a> |
-					<a href="/item/{story.id}"
-						>{story.comment_count} comment{story.comment_count !== 1 ? 's' : ''}</a
-					>
-					{#if canFlag(story)}
-						| <a href="#flag" onclick={(e) => { e.preventDefault(); flag(story.id); }}>{getFlaggedIds().has(story.id) ? 'un-flag' : 'flag'}</a>
-					{/if}
-				</div>
-			</div>
-		</div>
-	{/each}
+<!-- 行は共通ラッパ StoryList に集約（#151）。プロフィール下に揃える 40px インデントは据え置き。 -->
+<div style="padding-left: 40px;">
+	<StoryList
+		stories={data.submissions}
+		user={data.user}
+		votedIds={data.votedIds}
+		flaggedIds={data.flaggedIds}
+		rankStart={(data.page - 1) * 30}
+		moreHref={data.submissions.length === 30
+			? `/user/${data.username}/submissions?p=${data.page + 1}`
+			: null}
+	/>
 </div>
-
-{#if data.submissions.length === 30}
-	<div class="more-link">
-		<a href="/user/{data.username}/submissions?p={data.page + 1}" title={tooltipJa('More')}>More</a>
-	</div>
-{/if}

--- a/tests/e2e/user-pages.spec.ts
+++ b/tests/e2e/user-pages.spec.ts
@@ -4,6 +4,7 @@ import { signupNewUser, submitStory } from './helpers';
 /**
  * user の submissions / favorites ページは共通ラッパ StoryList に集約した（#151）。
  * 移行の主眼は「canonical row 化」＝以前は無かった hide リンク等の標準サブテキストが付くこと。
+ * hide リンクは `a[href="#hide"]` で掴む（テキストはロケールで hide/非表示 と変わるため・#152 レビュー）。
  */
 test.describe('user listing pages via StoryList', () => {
 	test('submissions が StoryList で描画され、canonical row（hide リンク）になる', async ({ page }) => {
@@ -19,22 +20,27 @@ test.describe('user listing pages via StoryList', () => {
 		// rank 番号が出る（StoryList の rankStart 由来）。
 		await expect(item.locator('.story-rank')).toHaveText('1.');
 		// 移行前は hide リンクが無かった。canonical row になり hide が出る（StoryListItem 由来）。
-		await expect(item.locator('.story-meta a', { hasText: 'hide' })).toBeVisible();
+		await expect(item.locator('.story-meta a[href="#hide"]')).toBeVisible();
 	});
 
-	test('submissions で hide すると行が即座に消える（StoryList の onhide）', async ({ page }) => {
+	test('submissions で hide した行はリロードを跨いで消えたままになる（StoryList onhide + サーバー除外）', async ({
+		page
+	}) => {
 		const title = `E2E SubHide ${Date.now()}`;
 		const username = await signupNewUser(page);
 		await submitStory(page, { title, text: 'sub hide body' });
 
 		await page.goto(`/user/${username}/submissions`);
-		const item = page
-			.locator('.story-item')
-			.filter({ has: page.locator('a.story-title', { hasText: title }) });
-		await expect(item).toBeVisible();
-		await item.locator('.story-meta a', { hasText: 'hide' }).click();
-		await expect(
-			page.locator('.story-item').filter({ has: page.locator('a.story-title', { hasText: title }) })
-		).toHaveCount(0, { timeout: 5000 });
+		const row = () =>
+			page.locator('.story-item').filter({ has: page.locator('a.story-title', { hasText: title }) });
+		await expect(row()).toBeVisible();
+
+		// クライアント楽観削除。
+		await row().locator('.story-meta a[href="#hide"]').click();
+		await expect(row()).toHaveCount(0, { timeout: 5000 });
+
+		// リロード後もサーバー側で除外され、復活しないこと（#152 で修正したバグの回帰防止）。
+		await page.reload();
+		await expect(row()).toHaveCount(0);
 	});
 });

--- a/tests/e2e/user-pages.spec.ts
+++ b/tests/e2e/user-pages.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+import { signupNewUser, submitStory } from './helpers';
+
+/**
+ * user の submissions / favorites ページは共通ラッパ StoryList に集約した（#151）。
+ * 移行の主眼は「canonical row 化」＝以前は無かった hide リンク等の標準サブテキストが付くこと。
+ */
+test.describe('user listing pages via StoryList', () => {
+	test('submissions が StoryList で描画され、canonical row（hide リンク）になる', async ({ page }) => {
+		const title = `E2E Submissions ${Date.now()}`;
+		const username = await signupNewUser(page);
+		await submitStory(page, { title, text: 'submissions storylist body' });
+
+		await page.goto(`/user/${username}/submissions`);
+		const item = page
+			.locator('.story-item')
+			.filter({ has: page.locator('a.story-title', { hasText: title }) });
+		await expect(item).toBeVisible();
+		// rank 番号が出る（StoryList の rankStart 由来）。
+		await expect(item.locator('.story-rank')).toHaveText('1.');
+		// 移行前は hide リンクが無かった。canonical row になり hide が出る（StoryListItem 由来）。
+		await expect(item.locator('.story-meta a', { hasText: 'hide' })).toBeVisible();
+	});
+
+	test('submissions で hide すると行が即座に消える（StoryList の onhide）', async ({ page }) => {
+		const title = `E2E SubHide ${Date.now()}`;
+		const username = await signupNewUser(page);
+		await submitStory(page, { title, text: 'sub hide body' });
+
+		await page.goto(`/user/${username}/submissions`);
+		const item = page
+			.locator('.story-item')
+			.filter({ has: page.locator('a.story-title', { hasText: title }) });
+		await expect(item).toBeVisible();
+		await item.locator('.story-meta a', { hasText: 'hide' }).click();
+		await expect(
+			page.locator('.story-item').filter({ has: page.locator('a.story-title', { hasText: title }) })
+		).toHaveCount(0, { timeout: 5000 });
+	});
+});


### PR DESCRIPTION
Closes #151。#147(PR #148) レビューが挙げた「user 一覧サブページが story 行を自前描画」の残重複を解消。

## やったこと
- **submissions / favorites**: `votedIds`/`flaggedIds` の Set 化・rank 計算・upvote/flag ハンドラ・More・`.story-item` markup の自前実装を撤去し `<StoryList />` 1本に（各約100行削減）。移行で **canonical row 化＝hide/past リンクが付く**（本家 HN の /submitted・/favorites と同じ）。40px インデントは wrapper で保持。
- **hidden**: 維持。hidden を除外せず表示し `un-hide` を出す逆セマンティクスで StoryListItem に嵌まらないため（理由をコメント明記）。

## テスト
- `user-pages.spec` 追加: submissions が StoryList 経由で描画・rank 表示・**canonical hide リンク**・onhide で即消去。2/2 green。
- 退行: hide/vote/auth 緑。型0。
- 実機: submissions が canonical row（`1 point by … | hide | discuss`・40px インデント）で描画されることを目視。

## 補足（テストの正直な穴）
#148 で直した `/front` の未ログイン30件キャップは、専用 e2e に「同一日 >30 件」が要りレート制限上作りにくいため未追加（ロジック＋ログイン経路パリティで担保）。必要なら wrangler 直挿入フィクスチャで追加可。