### PR TITLE
refactor: #153 /user/[id]/hidden を StoryList に集約（StoryListItem に un-hide 追加・4つ目の自前複製を解消）

### DIFF
--- a/src/lib/components/StoryList.svelte
+++ b/src/lib/components/StoryList.svelte
@@ -20,6 +20,9 @@
 		moreHref?: string | null;
 		/** url 無しでも常に [poll] タグを付ける（polls）。 */
 		forcePollTag?: boolean;
+		/** /hidden 用（#153）。各行を hide でなく un-hide で出し、un-hide で行を一覧から消す。
+		 *  この一覧は hidden を「表示」するので serverHiddenIds 等での除外はしない。 */
+		unhide?: boolean;
 	};
 
 	let {
@@ -30,7 +33,8 @@
 		serverHiddenIds = [],
 		rankStart = 0,
 		moreHref = null,
-		forcePollTag = false
+		forcePollTag = false,
+		unhide = false
 	}: Props = $props();
 
 	let votedSet = $derived(new Set<number>(votedIds));
@@ -42,7 +46,8 @@
 	function isHidden(id: number): boolean {
 		return serverHiddenSet.has(id) || localHiddenIds.has(id);
 	}
-	function onhide(id: number) {
+	// hide でも un-hide でも、成功した行はこの一覧から即座に消す（楽観更新）。
+	function removeFromView(id: number) {
 		const next = new Set(localHiddenIds);
 		next.add(id);
 		localHiddenIds = next;
@@ -64,7 +69,8 @@
 				initialVoted={votedSet.has(story.id)}
 				initialFlagged={flaggedSet.has(story.id)}
 				{forcePollTag}
-				{onhide}
+				onhide={unhide ? undefined : removeFromView}
+				onunhide={unhide ? removeFromView : undefined}
 			/>
 		{/if}
 	{/each}

--- a/src/lib/components/StoryListItem.svelte
+++ b/src/lib/components/StoryListItem.svelte
@@ -118,34 +118,34 @@
 		}
 	}
 
-	async function hide() {
-		const res = await fetch('/api/hide', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ storyId: story.id })
-		});
-		if (res.ok) {
+	// hide と un-hide は同じ /api/hide（toggle）を叩く。共有して二重実装を避け、in-flight ガードで
+	// 連打による再 toggle（un-hide のつもりが再 hide される）を防ぐ（#154 レビュー）。
+	let hideInFlight = false;
+	async function toggleHide(): Promise<boolean | null> {
+		if (hideInFlight) return null;
+		hideInFlight = true;
+		try {
+			const res = await fetch('/api/hide', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ storyId: story.id })
+			});
+			if (!res.ok) return null;
 			const result: { hidden: boolean } = await res.json();
-			if (result.hidden) {
-				onhide?.(story.id);
-			}
+			return result.hidden;
+		} finally {
+			hideInFlight = false;
 		}
 	}
 
-	// /hidden 用（#153）。/api/hide は toggle なので、hidden な story に投げると un-hide される。
-	// 解除できたら（hidden=false）親へ通知し、その行を /hidden 一覧から消す。
+	async function hide() {
+		if ((await toggleHide()) === true) onhide?.(story.id);
+	}
+
+	// /hidden 用（#153）。toggle なので hidden な story に投げると un-hide される。解除（hidden=false）できたら
+	// 親へ通知してその行を /hidden 一覧から消す。
 	async function unhide() {
-		const res = await fetch('/api/hide', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ storyId: story.id })
-		});
-		if (res.ok) {
-			const result: { hidden: boolean } = await res.json();
-			if (!result.hidden) {
-				onunhide?.(story.id);
-			}
-		}
+		if ((await toggleHide()) === false) onunhide?.(story.id);
 	}
 
 	function l(key: string): string {

--- a/src/lib/components/StoryListItem.svelte
+++ b/src/lib/components/StoryListItem.svelte
@@ -38,6 +38,9 @@
 		forcePollTag?: boolean;
 		/** hide 成功時に親へ通知（親側で localHiddenIds を更新するため） */
 		onhide?: (storyId: number) => void;
+		/** これが渡されると meta 行は hide でなく un-hide を出す（/hidden 用・#153）。
+		 *  クリックで POST /api/hide（toggle で hidden を解除）→ 成功で親へ通知し、その行を /hidden 一覧から消す。 */
+		onunhide?: (storyId: number) => void;
 		/** 一覧の「描画上の先頭行」だけ true。行コントロール解説 hint をここに1回だけ出す（#143）。
 		 *  絶対 rank ではなく描画 index で判定する＝2ページ目（rank=31〜）や rank 無しの /search でも先頭に出る。 */
 		assistFirst?: boolean;
@@ -51,6 +54,7 @@
 		initialFlagged,
 		forcePollTag = false,
 		onhide,
+		onunhide,
 		assistFirst = false
 	}: Props = $props();
 
@@ -128,6 +132,22 @@
 		}
 	}
 
+	// /hidden 用（#153）。/api/hide は toggle なので、hidden な story に投げると un-hide される。
+	// 解除できたら（hidden=false）親へ通知し、その行を /hidden 一覧から消す。
+	async function unhide() {
+		const res = await fetch('/api/hide', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ storyId: story.id })
+		});
+		if (res.ok) {
+			const result: { hidden: boolean } = await res.json();
+			if (!result.hidden) {
+				onunhide?.(story.id);
+			}
+		}
+	}
+
 	function l(key: string): string {
 		return label(key, locale);
 	}
@@ -180,7 +200,16 @@
 					deleted: story.user_deleted === 1 ? 1 : story.user_deleted === 0 ? 0 : null
 				})}</a>
 			<a href="/item/{story.id}">{timeAgo(story.created_at)}</a> |
-			{#if user}
+			{#if onunhide}
+				<a
+					href="#unhide"
+					title={tip('un-hide')}
+					onclick={(e) => {
+						e.preventDefault();
+						unhide();
+					}}>{l('un-hide')}</a
+				>
+			{:else if user}
 				<a
 					href="#hide"
 					title={tip('hide')}

--- a/src/routes/user/[id]/hidden/+page.svelte
+++ b/src/routes/user/[id]/hidden/+page.svelte
@@ -1,158 +1,23 @@
 <script lang="ts">
-	// このページは submissions/favorites と違い StoryList/StoryListItem に寄せていない（#151）。
-	// hidden を「除外せず表示」し各行に hide でなく un-hide を出す逆セマンティクスで、canonical row に嵌まらないため。
-	import { FLAG_KARMA_THRESHOLD } from '$lib/constants';
-	import { tooltipJa } from '$lib/i18n';
-	import { displayUsername } from '$lib/format';
-	import { timeAgo, extractDomain, isNewUser } from '$lib/ranking';
+	import StoryList from '$lib/components/StoryList.svelte';
 
 	let { data } = $props();
-	let votedIds = $derived(new Set(data.votedIds));
-	let flaggedIds = $derived(new Set(data.flaggedIds ?? []));
-	let localVotedIds = $state<Set<number> | null>(null);
-	let localPoints = $state<Record<number, number>>({});
-	let localUnhiddenIds = $state<Set<number>>(new Set());
-	let localFlaggedIds = $state<Set<number> | null>(null);
-	let localFlagCounts = $state<Record<number, number>>({});
-
-	function getVotedIds(): Set<number> {
-		return localVotedIds ?? votedIds;
-	}
-
-	function getFlaggedIds(): Set<number> {
-		return localFlaggedIds ?? flaggedIds;
-	}
-
-	function getFlagCount(story: { id: number; flag_count?: number }): number {
-		return localFlagCounts[story.id] ?? story.flag_count ?? 0;
-	}
-
-	function canFlag(story: { user_id: number }): boolean {
-		return !!data.user && data.user.karma >= FLAG_KARMA_THRESHOLD && story.user_id !== data.user.id;
-	}
-
-	async function flag(storyId: number) {
-		if (!data.user) {
-			window.location.href = '/login';
-			return;
-		}
-		const res = await fetch('/api/flag', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
-		});
-		if (res.ok) {
-			const result: { flagged: boolean; flagCount: number } = await res.json();
-			const next = new Set(getFlaggedIds());
-			if (result.flagged) next.add(storyId);
-			else next.delete(storyId);
-			localFlaggedIds = next;
-			localFlagCounts = { ...localFlagCounts, [storyId]: result.flagCount };
-		} else if (res.status === 403) {
-			const result = (await res.json()) as { error?: string };
-			alert(result.error || 'Permission denied');
-		}
-	}
-
-	function getPoints(story: { id: number; points: number }): number {
-		return localPoints[story.id] ?? story.points;
-	}
-
-	function isUnhidden(id: number): boolean {
-		return localUnhiddenIds.has(id);
-	}
-
-	async function unhide(storyId: number) {
-		const res = await fetch('/api/hide', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ storyId })
-		});
-		if (res.ok) {
-			const result: { hidden: boolean } = await res.json();
-			if (!result.hidden) {
-				const next = new Set(localUnhiddenIds);
-				next.add(storyId);
-				localUnhiddenIds = next;
-			}
-		}
-	}
-
-	async function vote(storyId: number) {
-		if (!data.user) {
-			window.location.href = '/login';
-			return;
-		}
-		const res = await fetch('/api/vote', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ itemId: storyId, itemType: 'story' })
-		});
-		if (res.ok) {
-			const result: { voteState: 'up' | 'down' | null; points: number } = await res.json();
-			localPoints = { ...localPoints, [storyId]: result.points };
-			const next = new Set(getVotedIds());
-			if (result.voteState === 'up') {
-				next.add(storyId);
-			} else {
-				next.delete(storyId);
-			}
-			localVotedIds = next;
-		}
-	}
 </script>
 
 <svelte:head>
 	<title>{data.username}'s hidden | ハッカーのろし</title>
 </svelte:head>
 
-<div class="story-list" style="padding-left: 40px;">
-	{#each data.hidden as story, i}
-		{#if !isUnhidden(story.id)}
-		<div class="story-item">
-			<span class="story-rank">{(data.page - 1) * 30 + i + 1}.</span>
-			<span class="story-vote">
-				<button
-					class="upvote"
-					class:voted={getVotedIds().has(story.id)}
-					onclick={() => vote(story.id)}
-					aria-label="upvote"
-				>
-					&#9650;
-				</button>
-			</span>
-			<div class="story-content" class:faded={story.dead === 1}>
-				<div class="story-title-line">
-					{#if story.url}
-						<a href={story.url} class="story-title">{story.title}</a>
-						<span class="story-domain">({extractDomain(story.url)})</span>
-					{:else}
-						<a href="/item/{story.id}" class="story-title">{story.title}</a>
-					{/if}
-					{#if story.type === 'poll'} <span class="story-tag">[poll]</span>{/if}
-					{#if getFlagCount(story) > 0} <span class="story-tag">[flagged]</span>{/if}
-					{#if story.dead === 1} <span class="story-tag">[dead]</span>{/if}
-				</div>
-				<div class="story-meta">
-					{getPoints(story)} point{getPoints(story) !== 1 ? 's' : ''} by
-					<a href="/user/{story.username}" style={isNewUser(story.user_created_at) ? 'color: #3c963c;' : ''}>{displayUsername({ username: story.username, deleted: story.user_deleted })}</a>
-					<a href="/item/{story.id}">{timeAgo(story.created_at)}</a> |
-					<a href="/item/{story.id}"
-						>{story.comment_count} comment{story.comment_count !== 1 ? 's' : ''}</a
-					>
-					| <a href="#unhide" title={tooltipJa('un-hide')} onclick={(e) => { e.preventDefault(); unhide(story.id); }}>un-hide</a>
-					{#if canFlag(story)}
-						| <a href="#flag" title={tooltipJa(getFlaggedIds().has(story.id) ? 'un-flag' : 'flag')} onclick={(e) => { e.preventDefault(); flag(story.id); }}>{getFlaggedIds().has(story.id) ? 'un-flag' : 'flag'}</a>
-					{/if}
-				</div>
-			</div>
-		</div>
-		{/if}
-	{/each}
+<!-- hidden を「表示」し各行に un-hide を出す。共通ラッパ StoryList の unhide モードで canonical row に集約（#153）。
+     この一覧は hidden を除外しないので serverHiddenIds は渡さない。40px インデントは据え置き。 -->
+<div style="padding-left: 40px;">
+	<StoryList
+		stories={data.hidden}
+		user={data.user}
+		votedIds={data.votedIds}
+		flaggedIds={data.flaggedIds}
+		rankStart={(data.page - 1) * 30}
+		moreHref={data.hidden.length === 30 ? `/user/${data.username}/hidden?p=${data.page + 1}` : null}
+		unhide
+	/>
 </div>
-
-{#if data.hidden.length === 30}
-	<div class="more-link">
-		<a href="/user/{data.username}/hidden?p={data.page + 1}" title={tooltipJa('More')}>More</a>
-	</div>
-{/if}

--- a/tests/e2e/user-pages.spec.ts
+++ b/tests/e2e/user-pages.spec.ts
@@ -43,4 +43,32 @@ test.describe('user listing pages via StoryList', () => {
 		await page.reload();
 		await expect(row()).toHaveCount(0);
 	});
+
+	test('/hidden も StoryList（unhide モード）で描画され、un-hide で行が消え復活しない', async ({
+		page
+	}) => {
+		const title = `E2E Unhide ${Date.now()}`;
+		const username = await signupNewUser(page);
+		await submitStory(page, { title, text: 'unhide body' });
+
+		// /newest で hide → /hidden に出る。
+		await page.goto('/newest');
+		const newestRow = page
+			.locator('.story-item')
+			.filter({ has: page.locator('a.story-title', { hasText: title }) });
+		await expect(newestRow).toBeVisible();
+		await newestRow.locator('.story-meta a[href="#hide"]').click();
+		await expect(newestRow).toHaveCount(0, { timeout: 5000 });
+
+		await page.goto(`/user/${username}/hidden`);
+		const row = () =>
+			page.locator('.story-item').filter({ has: page.locator('a.story-title', { hasText: title }) });
+		await expect(row()).toBeVisible();
+		// canonical row の un-hide リンク（StoryList unhide モード由来）。
+		await row().locator('.story-meta a[href="#unhide"]').click();
+		await expect(row()).toHaveCount(0, { timeout: 5000 });
+		// un-hide したのでリロードしても /hidden には戻らない。
+		await page.reload();
+		await expect(row()).toHaveCount(0);
+	});
 });


### PR DESCRIPTION
Closes #153。#152 レビュー finding #6（/hidden が canonical row を未だ自前複製）への対応。

## やったこと
- **StoryListItem**: `onunhide` プロップ追加。渡されると meta 行を hide でなく **un-hide** で出し、クリックで `POST /api/hide`（toggle で解除）→成功で `onunhide`。i18n の un-hide ラベル/tooltip を使う。
- **StoryList**: `unhide` モード追加。各行を un-hide で描画し `removeFromView` で即除去。hidden を*表示*するので除外はしない。
- **/hidden**: 自前の loop/vote/flag/unhide（~95行）を撤去し `<StoryList … unhide />` 1本に。**past リンク・i18n を獲得し submissions/favorites と同じ canonical row に揃う**（#152 で指摘された視覚乖離を解消）。40px インデント保持。

これで story 一覧の自前複製は **0**（list 13 + user 3 すべて StoryList）。

## テスト
- user-pages.spec に /hidden の **un-hide 即除去＋リロード非復活**を追加。3/3 green。
- StoryListItem 改変の退行: hide/vote/assist 緑。型0。
- 実機: /hidden が canonical row（`2 points by … | un-hide | discuss`・40px インデント・新規ユーザー緑）で描画されることを目視。