### PR TITLE
feat: コメント行の HN パリティ — context / prev リンク + 折り畳み (N more) (#157, #158)

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -294,9 +294,8 @@ export const TOOLTIP_JA = {
 	root: 'スレッドの先頭へ',
 	context: '前後の文脈を見る',
 	next: '次へ',
-	// prev は本家 HN レイアウトでは現状描画されないが、将来コメント間移動を
-	// 追加した際に流用できるよう辞書だけ先取りで持つ。tooltipJa('prev') が
-	// 呼ばれていない状態が正常。
+	// prev はコメントツリー行で next と対に描画する（#157）。本家 HN も
+	// item ページのコメント行に prev | next を出す（DFS 順の前後コメントへ）。
 	prev: '前へ',
 	reply: '返信',
 	More: '次のページ',

--- a/src/routes/item/[id]/+page.svelte
+++ b/src/routes/item/[id]/+page.svelte
@@ -277,6 +277,15 @@
 		}
 		return map;
 	});
+	// nextCommentId の逆写像。DFS 順での「前のコメント」を id ごとに引く。
+	// HN 互換の `prev | next` リンク用。
+	let prevCommentId = $derived.by(() => {
+		const map: Record<number, number> = {};
+		for (let i = 1; i < commentTree.length; i++) {
+			map[commentTree[i].id] = commentTree[i - 1].id;
+		}
+		return map;
+	});
 	let rootCommentId = $derived.by(() => {
 		const map: Record<number, number> = {};
 		function walk(node: CommentNode, rootId: number) {
@@ -452,6 +461,7 @@
 			{:else}
 				| <a href="/item/{parentStory.id}" title={tooltipJa('parent')} style="color: #828282;">parent</a>
 			{/if}
+			| <a href="/item/{parentStory.id}#item-{comment.id}" title={tooltipJa('context')} style="color: #828282;">context</a>
 			| on: <a href="/item/{parentStory.id}">{parentStory.title}</a>
 			{#if (comment.flag_count ?? 0) > 0} <span class="story-tag">[flagged]</span>{/if}
 			{#if targetCommentDead === 1} <span class="story-tag">[dead]</span>{/if}
@@ -553,6 +563,9 @@
 						{#if child.parent_id && child.parent_id !== comment.id}
 							| <a href="#item-{rootCommentId[child.id]}" title={tooltipJa('root')} style="color: #828282;">root</a>
 							| <a href="#item-{child.parent_id}" title={tooltipJa('parent')} style="color: #828282;">parent</a>
+						{/if}
+						{#if prevCommentId[child.id]}
+							| <a href="#item-{prevCommentId[child.id]}" title={tooltipJa('prev')} style="color: #828282;">prev</a>
 						{/if}
 						{#if nextCommentId[child.id]}
 							| <a href="#item-{nextCommentId[child.id]}" title={tooltipJa('next')} style="color: #828282;">next</a>
@@ -841,6 +854,9 @@
 						{#if comment.parent_id}
 							| <a href="#item-{rootCommentId[comment.id]}" title={tooltipJa('root')} style="color: #828282;">root</a>
 							| <a href="#item-{comment.parent_id}" title={tooltipJa('parent')} style="color: #828282;">parent</a>
+						{/if}
+						{#if prevCommentId[comment.id]}
+							| <a href="#item-{prevCommentId[comment.id]}" title={tooltipJa('prev')} style="color: #828282;">prev</a>
 						{/if}
 						{#if nextCommentId[comment.id]}
 							| <a href="#item-{nextCommentId[comment.id]}" title={tooltipJa('next')} style="color: #828282;">next</a>

--- a/src/routes/item/[id]/+page.svelte
+++ b/src/routes/item/[id]/+page.svelte
@@ -580,7 +580,7 @@
 								style="color: #828282;"
 							>{#if collapsed[child.id]}[+]{:else}[&ndash;]{/if}</a>
 							{#if collapsed[child.id] && descendantCounts[child.id] > 0}
-								<span style="color: #828282;"> ({descendantCounts[child.id]} {descendantCounts[child.id] === 1 ? 'reply' : 'replies'})</span>
+								<span style="color: #828282;"> ({descendantCounts[child.id]} more)</span>
 							{/if}
 						</span>
 					</div>
@@ -871,7 +871,7 @@
 								style="color: #828282;"
 							>{#if collapsed[comment.id]}[+]{:else}[&ndash;]{/if}</a>
 							{#if collapsed[comment.id] && descendantCounts[comment.id] > 0}
-								<span style="color: #828282;"> ({descendantCounts[comment.id]} {descendantCounts[comment.id] === 1 ? 'reply' : 'replies'})</span>
+								<span style="color: #828282;"> ({descendantCounts[comment.id]} more)</span>
 							{/if}
 						</span>
 					</div>

--- a/tests/e2e/comment-toggle.spec.ts
+++ b/tests/e2e/comment-toggle.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { signupNewUser, submitStory, findStoryIdByTitle, postComment } from './helpers';
 
 /**
  * Issue #122: コメント [–] トグル + root / parent / next リンク。
@@ -52,5 +53,102 @@ test.describe('comment toggle / root / parent / next', () => {
 		// next リンク（DFS 順で id 17 の次は 18）
 		const nextHref = await row17.locator('a:has-text("next")').first().getAttribute('href');
 		expect(nextHref).toBe('#item-18');
+	});
+});
+
+/**
+ * Issue #157 / #158: HN パリティ — prev リンク / context リンク（モード境界）/ 折り畳み (N more)。
+ *
+ * seed (db/seed.sql) の story id=8 (BBS) は 5 段の線形コメントツリー:
+ *   id 15 (root) → 16 → 17 → 18 → 19
+ * DFS 平坦化順 = 15, 16, 17, 18, 19。各コメント div は id="item-{id}"。
+ */
+test.describe('comment HN parity: prev / context / (N more)', () => {
+	// #157 prev: ツリー (mode==='story') の各行に DFS 前を指す prev リンクを足す。
+	// 先頭 (15) は prev 無し・末尾 (19) は next 無し。
+	test('prev リンクが DFS 前を指す。先頭に prev 無し・末尾に next 無し', async ({ page }) => {
+		await page.goto('/item/8');
+		await page.waitForLoadState('networkidle');
+
+		// id 17 の prev は DFS 前の 16、next は 18（既存テストと整合）。
+		const row17 = page.locator('#item-17');
+		const prevHref = await row17
+			.getByRole('link', { name: 'prev', exact: true })
+			.getAttribute('href');
+		expect(prevHref).toBe('#item-16');
+		const nextHref = await row17
+			.getByRole('link', { name: 'next', exact: true })
+			.getAttribute('href');
+		expect(nextHref).toBe('#item-18');
+
+		// 先頭 id 15 は DFS の最初なので prev リンクが無い。
+		await expect(
+			page.locator('#item-15').getByRole('link', { name: 'prev', exact: true })
+		).toHaveCount(0);
+		// 末尾 id 19 は DFS の最後なので next リンクが無い。
+		await expect(
+			page.locator('#item-19').getByRole('link', { name: 'next', exact: true })
+		).toHaveCount(0);
+	});
+
+	// #157 context: permalink (mode==='comment') の操作行のみ context を出す。
+	// ツリー (mode==='story') 側には context を出さない（モード境界）。
+	//
+	// 注: /item/[id] の load は story を先に引くため（+page.server.ts）、stories と
+	// comments は別テーブルで id 空間が衝突する。seed の comment id 15-19 は全て
+	// story id (1-46) と衝突し /item/{commentId} は story にすり替わる。コメント
+	// permalink (mode==='comment') を踏むには、story 衝突しない新規 comment を作って
+	// その timestamp リンクから辿る（item-text-x-alignment.spec.ts と同手法）。
+	test('context リンクは permalink のみ。ツリーには出ない', async ({ page }) => {
+		const title = `context permalink ${Date.now()}`;
+		await signupNewUser(page);
+		await submitStory(page, { title, url: `https://example.com/ctx-${Date.now()}` });
+		await page.goto('/newest');
+		const storyId = await findStoryIdByTitle(page, title);
+		await page.goto(`/item/${storyId}`);
+		await page.waitForLoadState('networkidle');
+		await postComment(page, 'comment for context permalink');
+		await page.waitForSelector('.comment-text', { state: 'visible', timeout: 15_000 });
+
+		// story ツリー (mode==='story') 側には context リンクが1つも無い。
+		await expect(page.getByRole('link', { name: 'context', exact: true })).toHaveCount(0);
+
+		// 作ったコメントの id を timestamp リンク (/item/{commentId}) から取得する。
+		const commentTsHref = await page
+			.locator('.comment-item .comment-head a')
+			.filter({ hasText: /ago/ })
+			.first()
+			.getAttribute('href');
+		const m = commentTsHref?.match(/\/item\/(\d+)/);
+		expect(m).not.toBeNull();
+		const commentId = Number(m![1]);
+
+		// コメント permalink (mode==='comment') を開く。context href は
+		// /item/{parentStoryId}#item-{commentId}。
+		await page.goto(`/item/${commentId}`);
+		await page.waitForLoadState('networkidle');
+		const contextHref = await page
+			.getByRole('link', { name: 'context', exact: true })
+			.first()
+			.getAttribute('href');
+		expect(contextHref).toBe(`/item/${storyId}#item-${commentId}`);
+	});
+
+	// #158 折り畳み: 畳むと子孫数を (N more) で表示（旧 "(N replies)" は廃止）。
+	test('折り畳みで子孫数が (N more) で表示される', async ({ page }) => {
+		await page.goto('/item/8');
+		await page.waitForLoadState('networkidle');
+
+		// id 16 の子孫は 17/18/19 の 3 つ。[–] を畳むと (3 more)。
+		const row16 = page.locator('#item-16');
+		await row16.locator('.comment-toggle a').click();
+		await expect(row16.locator('.comment-toggle')).toContainText('(3 more)');
+		// 旧文言 "replies" が出ないこと。
+		await expect(row16.locator('.comment-toggle')).not.toContainText('repl');
+
+		// root id 15 の子孫は 16/17/18/19 の 4 つ。畳むと (4 more)。
+		const row15 = page.locator('#item-15');
+		await row15.locator('.comment-toggle a').click();
+		await expect(row15.locator('.comment-toggle')).toContainText('(4 more)');
 	});
 });


### PR DESCRIPTION
## 関連 Issue
closes #157
closes #158

## 背景
HN パリティ巡回で見つけた、コメント行の本家との差分2件。本家 `news.ycombinator.com` の実物（item?id=48541777）で挙動を裏取りした上で合わせた。

## 変更内容（`src/routes/item/[id]/+page.svelte`・DB 変更なし）
### #157 context / prev
- **context**（コメント permalink = `mode==='comment'` のフォーカス行のみ）: `parent` の直後に `context` を追加。href `/item/{parentStory.id}#item-{comment.id}`＝親スレッドの該当コメント位置へ。story ツリーには出さない（本家どおり）。
- **prev**（ツリー行）: `nextCommentId` の逆写像 `prevCommentId`（DFS 隣接）を追加し、`next` を出す2箇所（child 行・comment 行）に `prev` を対で追加。並びは本家と同じ `root | parent | prev | next`。**先頭に prev 無し・末尾に next 無し**。
  - 本家確認: HN もツリーのコメント行に `prev | next` を出す（item?id=48541777 で `| prev | next`・`| prev`・`| next` を確認）。
- i18n は既存の `context`/`prev` 辞書を流用（新規辞書を増やさない・doctrine #3）。stale だった prev コメントを実態に更新。

### #158 折り畳み (N more)
- コメントを `[–]`→`[+]` で畳んだときの子孫数表示を `(N replies)`/`(1 reply)` → 本家の **`(N more)`**（単複 special-case 撤去）に。child 行・comment 行の2箇所。

## 検証
- `npm run test`: **210 unit 全 pass**。`npm run check`: 新規 ERROR 0。
- e2e `comment-toggle.spec`: **5 passed**（既存2 + 新規3＝prev アンカー/context モード境界/`(N more)`）。
- **実機ライブ確認**（ルール7・seed story 8 の 5段ツリー id15-19）: id15=prev無/id19=next無/中間=`root|parent|prev|next`、折り畳み=`[+] (3 more)`。
- 独立コードレビュー実施。must「HN はツリーに prev を出さない」は本家実物で**反証**（HN もツリーに prev/next を出す）→ 据え置き。should「stale な prev コメント」→ 修正済み。

## 補足（別件・本PR対象外）
レビュー/テスト中に、`/item/[id]` の load が story を comment より先に解決するため **story と comment の id 衝突時にコメント permalink が同 id の story に shadow される**既存の設計論点を発見。context は `parentStory.id` を指すので本PRの正しさには無影響。別 Issue 化を検討。