### PR TITLE
feat: フッターに Security リンクを追加（脆弱性報告先・HN パリティ） (#159)

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -24,6 +24,7 @@ export const UI_LABELS = {
 		FAQ: 'FAQ',
 		Lists: 'Lists',
 		API: 'API',
+		Security: 'Security',
 		GitHub: 'GitHub',
 		Search: 'Search',
 		asknew: 'asknew',
@@ -111,6 +112,7 @@ export const UI_LABELS = {
 		FAQ: 'FAQ',
 		Lists: '一覧',
 		API: 'API',
+		Security: 'Security',
 		GitHub: 'GitHub',
 		Search: '検索',
 		asknew: '新着の質問',
@@ -255,6 +257,7 @@ export const TOOLTIP_JA = {
 	FAQ: 'よくある質問',
 	Lists: '各種一覧',
 	API: '公開 API のドキュメント',
+	Security: 'セキュリティ・脆弱性の報告先',
 	GitHub: 'GitHub リポジトリ',
 	Search: '検索',
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -149,7 +149,7 @@
 
 	<footer class="hn-footer">
 		<a href="/guidelines" title={tip('Guidelines')}>{l('Guidelines')}</a> | <a href="/faq" title={tip('FAQ')}>{l('FAQ')}</a> | <a href="/lists" title={tip('Lists')}>{l('Lists')}</a> |
-		<a href="/api-docs" title={tip('API')}>{l('API')}</a> | <a href="https://github.com/kako-jun/hacker-noroshi" title={tip('GitHub')}>{l('GitHub')}</a> |
+		<a href="/api-docs" title={tip('API')}>{l('API')}</a> | <a href="https://github.com/kako-jun/hacker-noroshi/security" title={tip('Security')}>{l('Security')}</a> | <a href="https://github.com/kako-jun/hacker-noroshi" title={tip('GitHub')}>{l('GitHub')}</a> |
 		<a href="/search" title={tip('Search')}>{l('Search')}</a>
 		<form action="/search" method="get" class="hn-footer-search">
 			{l('Search')}: <input type="text" name="q" />

--- a/tests/e2e/tooltip-ja.spec.ts
+++ b/tests/e2e/tooltip-ja.spec.ts
@@ -23,6 +23,18 @@ test.describe('English label tooltip (title attribute)', () => {
 		await expect(apiLink).toHaveAttribute('title', '公開 API のドキュメント');
 	});
 
+	test('footer の "Security" リンクが GitHub security を指し、脆弱性報告先の title が付く（#159）', async ({
+		page
+	}) => {
+		await page.goto('/');
+		const securityLink = page.locator('.hn-footer a', { hasText: /^Security$/ });
+		await expect(securityLink).toHaveAttribute(
+			'href',
+			'https://github.com/kako-jun/hacker-noroshi/security'
+		);
+		await expect(securityLink).toHaveAttribute('title', 'セキュリティ・脆弱性の報告先');
+	});
+
 	test('/item/{id} で add comment ボタンに日本語 title が付く', async ({ page }) => {
 		// signup → submitStory で確実に「自分が著者の story」を用意し、
 		// /item/<id> を開いて add comment ボタンの title を検証する。


### PR DESCRIPTION
## 関連 Issue
closes #159

## 背景
HN パリティ巡回で発見。本家フッターは `… | API | Security | Legal | Apply to YC | Contact`。hacker-noroshi は `Apply to YC`/`Contact`/`Legal`（YC 固有）を GitHub 置換しているが、**Security（脆弱性報告先）**は OSS として体裁が良いので追加する。

## 変更内容（`src/routes/+layout.svelte` + `src/lib/i18n.ts`・DB 変更なし）
- フッターの `API` と `GitHub` の間に `Security` リンクを追加。リンク先 `https://github.com/kako-jun/hacker-noroshi/security`（GitHub のセキュリティポリシー／advisory・脆弱性は private advisory で受ける）。
- i18n: en/ja の label に `Security: 'Security'`（API/GitHub と同様、固有語は英語のまま）、TOOLTIP_JA に `Security: 'セキュリティ・脆弱性の報告先'`（#133 の二言語ホバー方式に乗せる）。
- e2e（`tooltip-ja.spec.ts`）: Security リンクの href と title を検証（既存 API リンクテストと同型）。

## 検証
- `npm run check`: 新規 ERROR 0。
- e2e `tooltip-ja.spec`: **6 passed**（既存5 + 新規1）。
- **実機ライブ確認**（ルール7）: フッターが `Guidelines | FAQ | Lists | API | Security | GitHub | Search` で描画、Security が API↔GitHub 間に表示。
- セルフレビュー: 既存 footer リンク（API/GitHub）と完全同型・i18n 3辞書すべて追加・リンク先は public repo の security タブで妥当。