### PR TITLE
test/dev hygiene: db:reset スクリプト + /admin/ipban flake 根治 (#166, #167)

### DIFF
--- a/db/reset.sql
+++ b/db/reset.sql
@@ -1,0 +1,17 @@
+-- ローカル D1 を初期化前の空状態に戻すための DROP スクリプト（#166）。
+-- db:init / db:seed は CREATE TABLE IF NOT EXISTS で DROP しないため、繰り返すと
+-- 行が累積して seed 固定データや ban 残留に依存する e2e が汚染される。
+-- `npm run db:reset` で reset.sql → schema.sql → seed.sql の順に流してクリーンにする。
+-- 子テーブルから先に落とす必要は SQLite では無い（FK は緩い）が、依存の薄い順に並べておく。
+DROP TABLE IF EXISTS ip_login_failures;
+DROP TABLE IF EXISTS flags;
+DROP TABLE IF EXISTS poll_options;
+DROP TABLE IF EXISTS ip_bans;
+DROP TABLE IF EXISTS username_history;
+DROP TABLE IF EXISTS hidden;
+DROP TABLE IF EXISTS favorites;
+DROP TABLE IF EXISTS sessions;
+DROP TABLE IF EXISTS votes;
+DROP TABLE IF EXISTS comments;
+DROP TABLE IF EXISTS stories;
+DROP TABLE IF EXISTS users;

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -78,15 +78,21 @@ D1 データベース ID: `185871af-76c3-403c-81c8-aede8f8cd100`
 
 ### seed 再投入の注意
 
-`db:seed` は INSERT のみで冪等ではない。既に seed 済みの DB に対して再実行すると UNIQUE 制約で落ちる。クリーンに入れ直す場合は
+`db:seed` は INSERT のみで冪等ではない。既に seed 済みの DB に対して再実行すると UNIQUE 制約で落ちる。`db:init`/`db:seed` は DROP しないため、繰り返すと local D1 に行が累積し、seed 固定 id や ban 残留に依存する e2e が汚染される。クリーンに入れ直すときは
+
+```bash
+npm run db:reset   # db/reset.sql (全テーブル DROP) → db:init → db:seed
+```
+
+を使う（#166）。`reset.sql` は全 12 テーブルを `DROP TABLE IF EXISTS` するので、テーブルごと作り直して AUTOINCREMENT も初期化される（DELETE と違い sqlite_sequence を別途消す必要がない）。e2e を回す前にクリーンにしたいときも `npm run db:reset`。
+
+明示的に DELETE で消したい場合は次でも同じ結果になる（AUTOINCREMENT を戻さないと poll_options が参照する story id (45/46) がずれるので sqlite_sequence も消すこと）:
 
 ```bash
 wrangler d1 execute hacker-noroshi-db --local --command \
   "DELETE FROM votes; DELETE FROM poll_options; DELETE FROM comments; DELETE FROM hidden; DELETE FROM favorites; DELETE FROM stories; DELETE FROM ip_bans; DELETE FROM ip_login_failures; DELETE FROM sessions; DELETE FROM flags; DELETE FROM username_history; DELETE FROM users; DELETE FROM sqlite_sequence;"
 npm run db:seed
 ```
-
-の順で全テーブルと autoincrement をリセットしてから流す。AUTOINCREMENT を戻さないと poll_options が参照する story id (45/46) がずれる。
 
 ## DB マイグレーション
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"db:init": "wrangler d1 execute hacker-noroshi-db --local --file=db/schema.sql",
 		"db:seed": "wrangler d1 execute hacker-noroshi-db --local --file=db/seed.sql",
+		"db:reset": "wrangler d1 execute hacker-noroshi-db --local --file=db/reset.sql && npm run db:init && npm run db:seed",
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"test:e2e": "playwright test",

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -1,6 +1,13 @@
 import { test, expect } from '@playwright/test';
 import { signupNewUser, promoteToAdmin, cleanIpBans } from './helpers';
 
+// run ごとにユニークな TEST-NET-2 (198.51.100.0/24・RFC 5737) アドレスを払い出す。
+// ip_bans に ip の UNIQUE 制約が無く、固定 IP だと前回 run の残留 ban と衝突して
+// ban→unban 後も行が残り toHaveCount(0) が非決定的に落ちていた（#167）。
+function uniqueTestIp(): string {
+	return `198.51.100.${(Date.now() % 254) + 1}`;
+}
+
 /**
  * Issue #122: /admin/ipban の admin 限定アクセスと手動 ban / unban。
  *
@@ -13,6 +20,11 @@ import { signupNewUser, promoteToAdmin, cleanIpBans } from './helpers';
  *       D1 直接 UPDATE で is_admin=1 に昇格させ、page を reload して使う。
  */
 test.describe('admin /admin/ipban', () => {
+	// 毎 run クリーンな状態から開始する（#167）。前回 run の afterAll が走らなかった／
+	// local D1 が累積している場合でも残留 ban に依存しないよう、開始前にも掃除する。
+	test.beforeAll(() => {
+		cleanIpBans();
+	});
 	test.afterAll(() => {
 		cleanIpBans();
 	});
@@ -38,20 +50,24 @@ test.describe('admin /admin/ipban', () => {
 		const banButton = page.locator('button:has-text("ban する")');
 		await expect(banButton).toBeEnabled();
 
-		// 手動で 1.2.3.4 を ban
-		const targetIp = '1.2.3.4';
+		// 手動で run ごとにユニークな IP を ban（#167・残留 ban との衝突回避）
+		const targetIp = uniqueTestIp();
 		const reason = `e2e #126 ${Date.now()}`;
 		const ipInput = page.locator('input[name="ip"]');
 		const reasonInput = page.locator('input[name="reason"]');
 		const expiresInput = page.locator('input[name="expiresIn"]');
-		await ipInput.fill(targetIp);
-		await reasonInput.fill(reason);
-		await expiresInput.fill('1');
-		// fill 後に DOM 値が保持されているか確認（hydration race の検出）。
-		// Svelte が `value={form?.ip ?? ''}` で再描画して空に戻したら ここで気付く。
-		expect(await ipInput.inputValue()).toBe(targetIp);
-		expect(await reasonInput.inputValue()).toBe(reason);
-		expect(await expiresInput.inputValue()).toBe('1');
+		// #167: 真の flake 原因はハイドレーション・レース。fill した直後に Svelte が
+		// `value={form?.ip ?? ''}` でフォームを再描画して入力値を空に戻すことがあり、
+		// 「enabled を待って1回 fill」だけでは非決定的に空になる（Received ""）。
+		// 値が定着するまで fill+検証をリトライして、ハイドレーション完了後の状態を掴む。
+		await expect(async () => {
+			await ipInput.fill(targetIp);
+			await reasonInput.fill(reason);
+			await expiresInput.fill('1');
+			expect(await ipInput.inputValue()).toBe(targetIp);
+			expect(await reasonInput.inputValue()).toBe(reason);
+			expect(await expiresInput.inputValue()).toBe('1');
+		}).toPass({ timeout: 10_000 });
 
 		await banButton.click();
 		// banError が出ていないことを先に確認


### PR DESCRIPTION
## 関連 Issue
closes #166
closes #167

production コードは変更なし（db スクリプト・テスト・docs のみ）。

## #166 db:reset
- `db:init`/`db:seed` は `CREATE TABLE IF NOT EXISTS` で DROP しないため、繰り返すと local D1 に行が累積し seed 依存 e2e を汚染する。
- `db/reset.sql`（全12テーブル `DROP TABLE IF EXISTS`）+ `npm run db:reset`（reset→init→seed）を追加。DROP なので AUTOINCREMENT も初期化される。
- `docs/operations.md` の seed 再投入手順を db:reset 案内に更新。

## #167 /admin/ipban flake 根治
- **真の原因はハイドレーション・レース**: `value={form?.ip ?? ''}` の Svelte 再描画が fill した入力値を空に戻し、「enabled を待って1回 fill」だと非決定的に `inputValue` が `""` になっていた（Received ""）。#126 の対処では不足だった。
- **修正**: fill+検証を `expect(async () => {...}).toPass()` でリトライし、**値が定着するまで（ハイドレーション完了後まで）粘る**。
- 併せて防御的衛生として: `ip_bans` に ip UNIQUE が無く固定 IP だと残留 ban と衝突しうるため **run 毎ユニーク IP**（TEST-NET-2）に変更、`beforeAll` でも `cleanIpBans()`（開始前掃除）。

## 検証
- `npm run db:reset` 後: 固定 seed が1セット（stories 46 / comments 44 / story8 ツリー id15-19 が5件）でクリーン。
- `admin.spec.ts:38`（ban→unban）を **db:reset 後に単発10回連続 → 10/10 pass**、full admin.spec を **--repeat-each=5 → 10/10 pass**。修正前は単発で 6/8 が `Received ""` で落ちていた。
- `npm run check`: 新規 ERROR 0（既存 18 は tests/ の @types/node・無関係）。

## 補足
本 flake は #164 とは無関係（admin/ipban は #164 で1ファイルも触っていない）。調査中に併発が見えたため別 Issue 化して根治した。